### PR TITLE
Create DB before connection and transact schema after

### DIFF
--- a/src/clj/orcpub/datomic.clj
+++ b/src/clj/orcpub/datomic.clj
@@ -1,6 +1,7 @@
 (ns orcpub.datomic
   (:require [com.stuartsierra.component :as component]
-            [datomic.api :as d]))
+            [datomic.api :as d]
+            [orcpub.db.schema :as schema]))
 
 (defrecord DatomicComponent [uri conn]
   component/Lifecycle
@@ -8,7 +9,10 @@
     (if (:conn this)
       this
       (do
-        (assoc this :conn (d/connect uri)))))
+        (d/create-database uri)
+        (let [connection (d/connect uri)]
+          (d/transact connection schema/all-schemas)
+          (assoc this :conn connection)))))
   (stop [this]
     (assoc this :conn nil)))
 


### PR DESCRIPTION
This will allow orcpub to create the database and schema on connection.
The create call returns false if the DB already exists, but the code moves on.
The schema transaction is idempotent, so there are not side effects of running it repeatedly.

This will allow a "one click" deploy, and `docker-compose up` to get things started with no fuss.