### PR TITLE
Pass original request host through nginx

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -8,6 +8,8 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_pass http://orcpub:8890;
     }
 


### PR DESCRIPTION
Orcpub looks at the request header `HOST` for oauth redirects and generating emails.
This configures Ngninx to pass it through the proxy.