### PR TITLE
Add subclass to class string

### DIFF
--- a/src/cljc/orcpub/pdf_spec.cljc
+++ b/src/cljc/orcpub/pdf_spec.cljc
@@ -26,11 +26,11 @@
 
 (defn class-string [classes levels]
   (s/join
-   " / "
+   "\n"
    (map
     (fn [cls-key]
-      (let [{:keys [class-name class-level subclass]} (levels cls-key)]
-        (str class-name " (" class-level ")")))
+      (let [{:keys [class-name class-level subclass-name]} (levels cls-key)]
+        (str class-name " [" subclass-name "](" class-level ")")))
     classes)))
 
 (defn ability-related-bonuses [suffix vals]


### PR DESCRIPTION
**Description**
- Adding subclass name to the class-string in pdf printing.
- Adding newline for splitting the class string, however this needs the pdf form to be updated

**Related to**
Implements #80 