### PR TITLE
Fix Figwheel compilation error from empty orcpub.dnd.e5.templates.ua-base ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ This is the code for OrcPub2.com. Many, many people have expressed interest in h
 
 ## Running
 
-To run a local instance of Orcpub, all you need is Docker, docker-compose, and the `docker-compose.yml` file and an SSL certificate. Simply edit the paths to the SSL certificate and key in the `web** service definition and run the following:
+To run a local instance of Orcpub, all you need is Docker, docker-compose, and the `docker-compose.yml` file and an SSL certificate. Simply edit the paths to the SSL certificate and key in the `web` service definition and run the following:
 
+```shell
    docker-compose pull
    docker-compose up -d
+```
 
 **NOTE:** If you need a quick SSL certificate, the script at `deploy/snakeoil.sh` will generate one. Links to Docker installation can be found [below](#with-docker).
 

--- a/src/cljc/orcpub/dnd/e5/templates/ua_base.cljc
+++ b/src/cljc/orcpub/dnd/e5/templates/ua_base.cljc
@@ -1,5 +1,5 @@
-#_(ns orcpub.dnd.e5.templates.ua-base
-  (:require [orcpub.template :as t]
+(ns orcpub.dnd.e5.templates.ua-base
+  #_(:require [orcpub.template :as t]
             [orcpub.common :as common]
             [orcpub.modifiers :as mods]
             [orcpub.entity-spec :as es]


### PR DESCRIPTION
Hi! I downloaded the repo to play around with it (and maybe add some support for my cleric's domain cantrips), and started the non-Docker setup instructions. Immediately after the step where you run Figwheel, I got an AssertionError:

```
Failed to compile build :dev from ["web/cljs" "src/cljc" "src/cljs"] in 59.363 seconds.
----  Exception    ----

  Assert failed: file:/Users/matthew/Documents/Code/orcpub/src/cljc/orcpub/dnd/e5/templates/ua_base.cljc does not provide a namespace
(first provides)
```

Sure enough, the `orcpub/dnd/e5/templates/ua_base.cljc` had commented out everything, including the namespace itself. `lein cljsbuild` works somehow, but Figwheel complains. To fix it, I uncommented the `ns` declaration, but made the `:require` commented-out.

Also updated a couple typos in the README.

(Going through the README, I see that it still refers to installing Datomic with Homebrew, but that option was removed in October, it seems. I may try to update that later.) 