### PR TITLE
Make "help" field of races and backgrounds editable

### DIFF
--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -5790,6 +5790,12 @@
        :option-pack
        race
        "m-l-5 m-b-20"]]
+     [:div.m-b-20
+       [:div.f-w-b
+        "Description"]
+       [textarea-field
+        {:value (get race :help)
+         :on-change #(dispatch [::races/set-race-prop :help %])}]]
      [:div.m-b-20.flex.flex-wrap
       [:div.m-r-5
        [labeled-dropdown
@@ -5925,6 +5931,12 @@
        :option-pack
        background
        "m-l-5 m-b-20"]]
+     [:div.m-b-20
+       [:div.f-w-b
+        "Description"]
+       [textarea-field
+        {:value (get background :help)
+         :on-change #(dispatch [::bg/set-background-prop :help %])}]]
      [:div [background-skill-proficiencies background]]
      [:div [background-languages background]]
      [:div [background-tool-proficiencies background]]


### PR DESCRIPTION
The "help" field of races and backgrounds is shown on the respective tabs of the character builder, and the included races and the one included background (acolyte) already use it.

This PR makes it possible to edit that field in the Race/Background builder. The text area is positioned directly below the name and option source inputs. It is called "Description" (instead of "Help") for consistency with the "descriptions" of spells etc. (and also because it seems more intuitive).

The whole thing seems to work fine, but please be aware it might not be optimally coded as I have no experience with Clojure (or UI design, for that matter).