### PR TITLE
Class Description and Subclass Flavor "help" text editable

### DIFF
--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -5297,7 +5297,7 @@
         "m-l-5"]]]
      #_[:div.m-b-20
         [:div.f-w-b
-         "Subclass Flavor"]
+         "Subclass Description"]
         [textarea-field
          {:value (get class :subclass-help)
           :on-change #(dispatch [::classes/set-class-prop :subclass-help %])}]]

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -5262,8 +5262,14 @@
         :option-pack
         class
         "m-l-5 m-b-20"]]]
+     [:div.m-b-20
+      [:div.f-w-b
+       "Description"]
+      [textarea-field
+       {:value (get class :help)
+        :on-change #(dispatch [::classes/set-class-prop :help %])}]]
      [:div.m-b-20.flex.flex-wrap
-      [:div.m-l-5.m-b-20.flex-grow-1
+      [:div.m-l-5.flex-grow-1
        [labeled-dropdown
         "Hit Die"
         {:items (map
@@ -5273,7 +5279,7 @@
                  [6 8 10 12])
          :value (:hit-die class)
          :on-change #(dispatch [::classes/set-class-prop :hit-die (js/parseInt %)])}]]
-      [:div.m-l-5.m-b-20.flex-grow-1
+      [:div.m-l-5.flex-grow-1
        [labeled-dropdown
         "Pick Subclass at Level"
         {:items (map
@@ -5283,12 +5289,23 @@
                  (range 1 4))
          :value (:subclass-level class)
          :on-change #(dispatch [::classes/set-class-prop :subclass-level (js/parseInt %)])}]]
-      [:div.m-b-20.flex-grow-1
+      [:div.flex-grow-1
        [class-input-field
         "Subclass Title"
         :subclass-title
         class
-        "m-l-5 m-b-20"]]]
+        "m-l-5"]]]
+     #_[:div.m-b-20
+        [:div.f-w-b
+         "Subclass Flavor"]
+        [textarea-field
+         {:value (get class :subclass-help)
+          :on-change #(dispatch [::classes/set-class-prop :subclass-help %])}]]
+     [:div.m-b-20
+      [class-input-field
+       "Subclass Flavor"
+       :subclass-help
+       class]]
      [:div.m-b-30
       [:div.f-s-24.f-w-b.m-b-10 "Saving Throws"]
       [:div.flex.flex-wrap


### PR DESCRIPTION
Going off of bewley's PR, the same thing was possible with Classes and, sort of, with Subclasses so I went ahead and added it to the class builder UI. I named the ":help" section of the Class as Description, as with his version, but the ":subclass-help" works a bit differently so I named it accordingly.

Commented out is the section of code to make the single line Subclass Flavor input into a textarea input which allows for line breaks etc. I think the single line looks better and it's more than functional but the option's there if anyone wants to change it on a local version.

Also removed some css ".m-b-20" tags from the "Hit Die", "Subclass at Level" and "Subclass Title" just for the sake of it looking good and not having a pointless giant gap