### PR TITLE
Show monster damage resistances properly

### DIFF
--- a/src/cljs/orcpub/dnd/e5/spell_subs.cljs
+++ b/src/cljs/orcpub/dnd/e5/spell_subs.cljs
@@ -979,7 +979,7 @@
                 condition-immunity
                 language]} props
         filtered-languages (true-types language)
-        filtered-resistances (true-types damage-vulnerability)
+        filtered-resistances (true-types damage-resistance)
         filtered-damage-immunities (true-types damage-immunity)
         filtered-vulnerabilities (true-types damage-vulnerability)
         filtered-condition-immunities (true-types condition-immunity)]


### PR DESCRIPTION
Trivial fix for #133 with one caveat.

Context: Monsters have two fields for resistances: the list (string-bool map) "damage-resistance" and the string "damage-resistances" (with -s) to be displayed. The latter is computed automatically, but then stored as a regular field/entry in the monster data.

The caveat of my fix is that "damage-resistances" isn't immediately updated when importing an .orcbrew file. The only way I found to do this reliably is to edit the monster. However, the UI seems to always show the right thing, so this shouldn't be noticeable for the user.