### PR TITLE
Typo "invocations" -> "invocation"

### DIFF
--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7086,7 +7086,7 @@
   [my-content-type
    name
    plugin
-   "eldritch invocations"
+   "eldritch invocation"
    ::e5/invocations
    "warlock-eye"
    ::classes/new-invocation


### PR DESCRIPTION
Apparently the site auto adds an `s`