### PR TITLE
Fixed speed modifier type not displaying on the Item Builder

### DIFF
--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -3904,7 +3904,7 @@
         (let [speed-mod-type @(subscribe [::mi/speed-mod-type type-kw])]
           ^{:key type-kw}
           [:div.flex.align-items-c
-           [:div.w-100 (common/safe-capitalize-kw (type-kw))]
+           [:div.w-100 (common/safe-capitalize-kw type-kw)]
            [:div
             [dropdown
              {:value speed-mod-type

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -3904,7 +3904,7 @@
         (let [speed-mod-type @(subscribe [::mi/speed-mod-type type-kw])]
           ^{:key type-kw}
           [:div.flex.align-items-c
-           [:div.w-100 (common/safe-capitalize-kw (name type-kw))]
+           [:div.w-100 (common/safe-capitalize-kw (type-kw))]
            [:div
             [dropdown
              {:value speed-mod-type

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -3904,7 +3904,7 @@
         (let [speed-mod-type @(subscribe [::mi/speed-mod-type type-kw])]
           ^{:key type-kw}
           [:div.flex.align-items-c
-           [:div.w-100 (common/safe-capitalize type-kw)]
+           [:div.w-100 (common/safe-capitalize (name type-kw))]
            [:div
             [dropdown
              {:value speed-mod-type

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -3904,7 +3904,7 @@
         (let [speed-mod-type @(subscribe [::mi/speed-mod-type type-kw])]
           ^{:key type-kw}
           [:div.flex.align-items-c
-           [:div.w-100 (common/safe-capitalize (name type-kw))]
+           [:div.w-100 (common/safe-capitalize-kw (name type-kw))]
            [:div
             [dropdown
              {:value speed-mod-type


### PR DESCRIPTION
Easy fix that displays which of the Speed Bonus modifiers are associated with the form fields.

![Sans titre](https://user-images.githubusercontent.com/17627086/61704284-a9852480-ad43-11e9-930e-449b75e8fab3.png)
