### PR TITLE
Encounter num fix

### DIFF
--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -6777,7 +6777,7 @@
                            (:type monster)
                            (:subtypes monster)
                            (:alignment monster)]]
-                         [:div.f-w-b.f-s-24 (str "(" num ")")]
+                         [:div.f-w-b.f-s-24 (str "(" (or num 0) ")")]
                          [:div.flex.flex-wrap
                           (doall
                            (map

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -6399,8 +6399,8 @@
          "Number"
          {:items (map
                   value-to-item
-                  (range 1 21))
-          :value (or num 1)
+                  (range 0 21))
+          :value (or num 0)
           :on-change on-num-change}]])]))
 
 (defn character-selector [index {:keys [character]} on-change]
@@ -6777,7 +6777,7 @@
                            (:type monster)
                            (:subtypes monster)
                            (:alignment monster)]]
-                         [:div.f-w-b.f-s-24 (str "(" (or num 1) ")")]
+                         [:div.f-w-b.f-s-24 (str "(" num ")")]
                          [:div.flex.flex-wrap
                           (doall
                            (map


### PR DESCRIPTION
Fixes Issue #279 

The issue arose from the fact that adding a monster to an encounter displayed the default amount as 1 but didn't actually set it to one. It only sets the amount `on-change`

I couldn't figure out how to actually set the default value to something other than nil, without the `on-change`, so I left it at nil and set the displayed value to 0. This should prompt users to change it manually which'll fix the bug. Bit of a roundabout fix but it works and it's the only thing I could figure out that does work