### PR TITLE
Fixes for character-ability's being limited to 20.  New max is 35.

### DIFF
--- a/src/cljc/orcpub/dnd/e5/character.cljc
+++ b/src/cljc/orcpub/dnd/e5/character.cljc
@@ -19,7 +19,8 @@
 (spec/def ::race string?)
 (spec/def ::darkvision boolean?)
 (spec/def ::speed nat-int?)
-(spec/def ::character-ability (spec/int-in 1 21))
+; ::character-ability changed to 1 35 for max ability score's of 35 because tome's and other magical items can increase beyond 20
+(spec/def ::character-ability (spec/int-in 1 35))
 (spec/def ::initiative int?)
 (spec/def ::savings-throw keyword?)
 (spec/def ::savings-throws (spec/* ::savings-throw))

--- a/src/cljc/orcpub/dnd/e5/magic_items.cljc
+++ b/src/cljc/orcpub/dnd/e5/magic_items.cljc
@@ -2660,18 +2660,36 @@ The talisman has 6 charges. If you are wearing or holding it, you can use an act
      name-key "Tome of Clear Thought"
      ::type :wondrous-item
      ::rarity :very-rare
+     ::description "This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Intelligence score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century. (this doesn't apply modifiers automatically, once you have read the Tome remove this one and add the read version)"
+     }{
+     name-key "Tome of Clear Thought (read with modifiers)"
+     ::type :wondrous-item
+     ::rarity :very-rare
      ::description "This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Intelligence score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century."
+     ::modifiers [(mod5e/ability ::char5e/int 2)]
      }{
      name-key "Tome of Leadership and Influence"
      ::type :wondrous-item
      ::rarity :very-rare
-     ::description "This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Charisma score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century."
+     ::description "This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Charisma score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century. (this doesn't apply modifiers automatically, once you have read the Tome remove this one and add the read version)"
      }{
+       name-key "Tome of Leadership and Influence (read with modifiers)"
+       ::type :wondrous-item
+       ::rarity :very-rare
+       ::description "This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Charisma score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century."
+       ::modifiers [(mod5e/ability ::char5e/cha 2)]
+       }{
      name-key "Tome of Understanding"
      ::type :wondrous-item
      ::rarity :very-rare
-     ::description "This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Wisdom score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century."
+     ::description "This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Wisdom score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century. (this doesn't apply modifiers automatically, once you have read the Tome remove this one and add the read version)"
      }{
+       name-key "Tome of Understanding (read with modifiers)"
+       ::type :wondrous-item
+       ::rarity :very-rare
+       ::description "This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book’s contents and practicing its guidelines, your Wisdom score increases by 2, as does your maximum for that score. The manual then loses its magic, but regains it in a century."
+       ::modifiers [(mod5e/ability ::char5e/wis 2)]
+       }{
      name-key "Trident of Fish Command"
      ::type :weapon
      ::item-subtype :trident


### PR DESCRIPTION
## Description:
Fixes character-ability's being limited to 20.  New max is 35 due to magic items being able to bump this beyond 20.
Fixes for Tome's to automatically apply modifiers - there are now two choices 
- read applies modifiers automatically
- unread does not apply modifiers.

Fixes #332 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)