### PR TITLE
Added EMAIL_FROM_ADDRESS environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ EMAIL_SERVER_URL: '' # DNS name of your smtp server
 EMAIL_ACCESS_KEY: '' # User for the mail server
 EMAIL_SECRET_KEY: '' # Password for the user
 EMAIL_SERVER_PORT: 587 # Mail server port
+EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com' # Email address to send from
 EMAIL_SSL: 'false' # Should SSL be used? Gmail requires this.
 EMAIL_TLS: 'false' # Should TLS be used? 
 DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=yourpassword # Url for the database
@@ -193,6 +194,7 @@ EMAIL_SERVER_URL: '' # Url to a smtp server
 EMAIL_ACCESS_KEY: '' # User for the mail server
 EMAIL_SECRET_KEY: '' # Password for the user
 EMAIL_SERVER_PORT: 587 # Mail server port
+EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com' # Email address to send from
 EMAIL_SSL: 'false' # Should SSL be used? Gmail requires this.
 DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=yourpassword # Url for the database
 ADMIN_PASSWORD: supersecretpassword

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ EMAIL_ACCESS_KEY: '' # User for the mail server
 EMAIL_SECRET_KEY: '' # Password for the user
 EMAIL_SERVER_PORT: 587 # Mail server port
 EMAIL_FROM_ADDRESS: '' # Email address to send from, will default to 'no-reply@orcpub.com'
+EMAIL_ERRORS_TO: '' # Email address that errors will be sent to
 EMAIL_SSL: 'false' # Should SSL be used? Gmail requires this.
 EMAIL_TLS: 'false' # Should TLS be used? 
 DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=yourpassword # Url for the database
 ADMIN_PASSWORD: supersecretpassword #The datomic admin password (should be diffrent than the DATOMIC_PASSWORD)
 DATOMIC_PASSWORD: yourpassword #The datomic application password
+SIGNATURE: '<change me to something unique>' # The Secret used to hash your password in the browser, 20+ characters recommended
 ```
 
 The `ADMIN_PASSWORD` and `DATOMIC_PASSWORD`
@@ -195,10 +197,12 @@ EMAIL_ACCESS_KEY: '' # User for the mail server
 EMAIL_SECRET_KEY: '' # Password for the user
 EMAIL_SERVER_PORT: 587 # Mail server port
 EMAIL_FROM_ADDRESS: '' # Email address to send from, will default to 'no-reply@orcpub.com'
+EMAIL_ERRORS_TO: '' # Email address that errors will be sent to
 EMAIL_SSL: 'false' # Should SSL be used? Gmail requires this.
 DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=yourpassword # Url for the database
 ADMIN_PASSWORD: supersecretpassword
 DATOMIC_PASSWORD: yourpassword
+SIGNATURE: '<change me to something unique>' # The Secret used to hash your password in the browser, 20+ characters recommended
 ```
 
 To change the datomic passwords you can do it through the environment variables `ADMIN_PASSWORD_OLD` and `DATOMIC_PASSWORD_OLD` start the container once, then set the `ADMIN_PASSWORD` and `DATOMIC_PASSWORD` to your new passwords.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ EMAIL_SERVER_URL: '' # DNS name of your smtp server
 EMAIL_ACCESS_KEY: '' # User for the mail server
 EMAIL_SECRET_KEY: '' # Password for the user
 EMAIL_SERVER_PORT: 587 # Mail server port
-EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com' # Email address to send from
+EMAIL_FROM_ADDRESS: '' # Email address to send from, will default to 'no-reply@orcpub.com'
 EMAIL_SSL: 'false' # Should SSL be used? Gmail requires this.
 EMAIL_TLS: 'false' # Should TLS be used? 
 DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=yourpassword # Url for the database
@@ -194,7 +194,7 @@ EMAIL_SERVER_URL: '' # Url to a smtp server
 EMAIL_ACCESS_KEY: '' # User for the mail server
 EMAIL_SECRET_KEY: '' # Password for the user
 EMAIL_SERVER_PORT: 587 # Mail server port
-EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com' # Email address to send from
+EMAIL_FROM_ADDRESS: '' # Email address to send from, will default to 'no-reply@orcpub.com'
 EMAIL_SSL: 'false' # Should SSL be used? Gmail requires this.
 DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=yourpassword # Url for the database
 ADMIN_PASSWORD: supersecretpassword

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -11,8 +11,8 @@ services:
       EMAIL_ACCESS_KEY: ''
       EMAIL_SECRET_KEY: ''
       EMAIL_SERVER_PORT: 587
-      # Email address to send from
-      EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com'
+      # Email address to send from, will default to 'no-reply@orcpub.com'
+      EMAIL_FROM_ADDRESS: ''
       # Email address to send errors to
       EMAIL_ERRORS_TO: ''
       EMAIL_SSL: 'TRUE'

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -19,6 +19,8 @@ services:
       EMAIL_TLS: 'FALSE'
       # Datomic connection string - Make sure the <change this> matches the DATOMIC_PASSWORD below 
       DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=<change this>
+      # The secret used to hash your password in the browser, 20+ characters recommended
+      SIGNATURE: '<change me to something unique>'
     depends_on:
       - datomic
     restart: always

--- a/docker-compose-build.yaml
+++ b/docker-compose-build.yaml
@@ -11,6 +11,8 @@ services:
       EMAIL_ACCESS_KEY: ''
       EMAIL_SECRET_KEY: ''
       EMAIL_SERVER_PORT: 587
+      # Email address to send from
+      EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com'
       # Email address to send errors to
       EMAIL_ERRORS_TO: ''
       EMAIL_SSL: 'TRUE'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
       EMAIL_ACCESS_KEY: ''
       EMAIL_SECRET_KEY: ''
       EMAIL_SERVER_PORT: 587
+      # Email address to send from
+      EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com'
       # Email address to send errors to
       EMAIL_ERRORS_TO: ''
       EMAIL_SSL: 'FALSE'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       EMAIL_ACCESS_KEY: ''
       EMAIL_SECRET_KEY: ''
       EMAIL_SERVER_PORT: 587
-      # Email address to send from
-      EMAIL_FROM_ADDRESS: 'no-reply@orcpub.com'
+      # Email address to send from, will default to 'no-reply@orcpub.com'
+      EMAIL_FROM_ADDRESS: ''
       # Email address to send errors to
       EMAIL_ERRORS_TO: ''
       EMAIL_SSL: 'FALSE'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       EMAIL_TLS: 'FALSE'
       # Datomic connection string - Make sure the <change this> matches the DATOMIC_PASSWORD below 
       DATOMIC_URL: datomic:free://datomic:4334/orcpub?password=<change this>
+      # The secret used to hash your password in the browser, 20+ characters recommended
+      SIGNATURE: '<change me to something unique>'
     depends_on:
       - datomic
     restart: always

--- a/src/clj/orcpub/email.clj
+++ b/src/clj/orcpub/email.clj
@@ -37,7 +37,7 @@
 
 (defn send-verification-email [base-url {:keys [email username first-and-last-name]} verification-key]
   (postal/send-message (email-cfg)
-                       {:from "OrcPub Team <no-reply@orcpub.com>"
+                       {:from (str "OrcPub Team <" (environ/env :email-from-address) ">")
                         :to email
                         :subject "OrcPub Email Verification"
                         :body (verification-email
@@ -70,7 +70,7 @@
 
 (defn send-reset-email [base-url {:keys [email username first-and-last-name]} reset-key]
   (postal/send-message (email-cfg)
-                       {:from "OrcPub Team <no-reply@orcpub.com>"
+                       {:from (str "OrcPub Team <" (environ/env :email-from-address) ">")
                         :to email
                         :subject "OrcPub Password Reset"
                         :body (reset-password-email
@@ -80,7 +80,7 @@
 (defn send-error-email [context exception]
   (if (not-empty (environ/env :email-errors-to))
     (postal/send-message (email-cfg)
-                         {:from (str "OrcPub Errors <" (environ/env :email-errors-to) ">")
+                         {:from (str "OrcPub Errors <" (environ/env :email-from-address) ">")
                           :to (str (environ/env :email-errors-to))
                           :subject "Exception"
                           :body [{:type "text/plain"

--- a/src/clj/orcpub/email.clj
+++ b/src/clj/orcpub/email.clj
@@ -3,6 +3,7 @@
             [postal.core :as postal]
             [environ.core :as environ]
             [clojure.pprint :as pprint]
+            [clojure.string :as s]
             [orcpub.route-map :as routes]
             [cuerdas.core :as str]))
 
@@ -36,7 +37,7 @@
    })
 
 (defn emailfrom []
-  (if (not (clojure.string/blank? (environ/env :email-from-address))) (environ/env :email-from-address) (str "no-reply@orcpub.com")))
+  (if (not (s/blank? (environ/env :email-from-address))) (environ/env :email-from-address) (str "no-reply@orcpub.com")))
 
 (defn send-verification-email [base-url {:keys [email username first-and-last-name]} verification-key]
   (postal/send-message (email-cfg)

--- a/src/clj/orcpub/email.clj
+++ b/src/clj/orcpub/email.clj
@@ -35,9 +35,12 @@
    :tls (or (str/to-bool (environ/env :email-tls)) nil)
    })
 
+(defn emailfrom []
+  (if (not (clojure.string/blank? (environ/env :email-from-address))) (environ/env :email-from-address) (str "no-reply@orcpub.com")))
+
 (defn send-verification-email [base-url {:keys [email username first-and-last-name]} verification-key]
   (postal/send-message (email-cfg)
-                       {:from (str "OrcPub Team <" (environ/env :email-from-address) ">")
+                       {:from (str "OrcPub Team <" (emailfrom) ">")
                         :to email
                         :subject "OrcPub Email Verification"
                         :body (verification-email
@@ -70,7 +73,7 @@
 
 (defn send-reset-email [base-url {:keys [email username first-and-last-name]} reset-key]
   (postal/send-message (email-cfg)
-                       {:from (str "OrcPub Team <" (environ/env :email-from-address) ">")
+                       {:from (str "OrcPub Team <" (emailfrom) ">")
                         :to email
                         :subject "OrcPub Password Reset"
                         :body (reset-password-email
@@ -80,7 +83,7 @@
 (defn send-error-email [context exception]
   (if (not-empty (environ/env :email-errors-to))
     (postal/send-message (email-cfg)
-                         {:from (str "OrcPub Errors <" (environ/env :email-from-address) ">")
+                         {:from (str "OrcPub Errors <" (emailfrom) ">")
                           :to (str (environ/env :email-errors-to))
                           :subject "Exception"
                           :body [{:type "text/plain"


### PR DESCRIPTION
## Description:

Added a new Environment Variable: EMAIL_FROM_ADDRESS

This allows you to set the email address orc pub is sending from. Changing it from the hardcoded 'no-reply@orcpub.com' to what ever you want.

## Checklist:
  - [x] The code change is tested and works locally.
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation if necessary
  - [X] There is no commented out code in this PR.
  - [X] My changes generate no new warnings (check the console)