### PR TITLE
[WIP] Homebrew options improvements

### DIFF
--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -2686,6 +2686,15 @@
                            (assoc m key num))))))
 
 (reg-event-db
+ ::bg5e/toggle-feature-value-prop
+ background-interceptors
+ (fn [background [_ key num]]
+   (update background :props (fn [m]
+                         (if (= (get m key) num)
+                           (dissoc m key)
+                           (assoc m key num))))))
+
+(reg-event-db
  ::race5e/toggle-race-prop
  race-interceptors
  (fn [race [_ key]]
@@ -3534,6 +3543,28 @@
  race-interceptors
  (fn [race [_ index]]
    (update race :spells common/remove-at-index index)))
+
+(reg-event-db
+ ::feats5e/set-feat-spell-level
+ feat-interceptors
+ (fn [feat [_ index level]]
+   (cond-> feat
+     (nil? (:spells feat)) (assoc :spells [])
+     true (assoc-in [:spells index :level] level))))
+
+(reg-event-db
+ ::feats5e/set-feat-spell-value
+ feat-interceptors
+ (fn [feat [_ index value]]
+   (cond-> feat
+     (nil? (:spells feat)) (assoc :spells [])
+     true (assoc-in [:spells index :value] value))))
+
+(reg-event-db
+ ::feats5e/delete-feat-spell
+ feat-interceptors
+ (fn [feat [_ index]]
+   (update feat :spells common/remove-at-index index)))
 
 (defn reg-option-traits [option-name option-key interceptors]
   (reg-event-db

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -4581,7 +4581,7 @@
             (= num (get-in feat [:props kw]))
             false
             #(dispatch [::feats/toggle-feat-value-prop kw num])])])
-      (range 3 5)))]])
+      (range 1 5)))]])
 
 (defn option-armor-proficiency [option toggle-map-prop-event]
   [:div.m-b-20

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -4429,6 +4429,30 @@
     [:div.f-s-18.f-w-b.m-b-10 "Other Tools"]
     [tool-prof-checkboxes background equip/misc-tools]]])
 
+(defn background-weapon-proficiency [background]
+  [:div.m-b-20
+   [:div.f-s-18.f-w-b.m-b-10 "Weapon Proficiency"]
+   [:div.flex.flex-wrap
+    [:div.m-r-20.m-b-10
+     (let [kw :improvised-weapons-prof]
+       [comps/labeled-checkbox
+        "You gain proficiency with improvised weapons"
+        (get-in background [:props kw])
+        false
+        #(dispatch [::bg/toggle-background-prop kw])])]
+    (doall
+     (map
+      (fn [num]
+        ^{:key num}
+        [:div.m-r-20.m-b-10
+         (let [kw :weapon-prof-choice]
+           [comps/labeled-checkbox
+            (str "You gain proficiency with " num " weapons of your choice")
+            (= num (get-in background [:props kw]))
+            false
+            #(dispatch [::bg/toggle-feature-value-prop kw num])])])
+      (range 1 5)))]])
+
 (defn background-starting-equipment [background]
   [:div.m-t-20.m-b-20
    [:div.f-s-24.f-w-b.m-b-10 "Starting Equipment"]
@@ -4988,6 +5012,7 @@
      [:div [feat-initiative-bonuses feat]]
      [:div [feat-misc-modifiers feat]]
      [:div [feat-spellcasting feat]]
+     [:div [option-spells feat ::feats/set-feat-spell-level ::feats/set-feat-spell-value ::feats/delete-feat-spell]]
      [:div [option-skill-proficiency-or-expertise feat ::feats/toggle-feat-map-prop]]
      [:div [option-tool-proficiency-or-expertise feat ::feats/toggle-feat-map-prop]]]))
 
@@ -6081,6 +6106,7 @@
      [:div [background-skill-proficiencies background]]
      [:div [background-languages background]]
      [:div [background-tool-proficiencies background]]
+     [:div [background-weapon-proficiency background]]
      [:div [background-starting-equipment background]]
      [:div
       [option-traits


### PR DESCRIPTION
## Description:

This PR is a WIP for the items listed below. Currently, the options appear on the builder pages and save to the homebrew object, but do not appear to be read correctly in the character builder / viewers. If someone with more familiarity can point me in the right direction (data model issues, something new not added to a reader / renderer?), it would expedite me finishing this. Otherwise, I will poke around more when I have time.

Adds some simple features and changes to some homebrew builder types:
  - [x] Change range of Feat "Weapon Proficiency" choices from 3-5 to 1-5
  - [ ] Add "Weapon Prociency" choice to Background builder
  - [ ] Add Spell "unlocking" for specific spells to Feat builder

**Related issue (if applicable):**
Addresses #50 (not complete)
Addresses https://github.com/Orcpub/orcpub/issues/172#issuecomment-627647588

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation if necessary
  - [ ] There is no commented out code in this PR.
  - [ ] My changes generate no new warnings (check the console)