### PR TITLE
Fixes #503 [Bug] Email address validator doesn't comply with new TLD

### DIFF
--- a/src/cljc/orcpub/dice.cljc
+++ b/src/cljc/orcpub/dice.cljc
@@ -39,7 +39,7 @@
   (if-let [[_ num-str sides-str plus-minus-str mod-str :as match]
            (re-matches dice-regex dice-text)]
     (let [num (or (parse-int num-str) 1)
-          sides (or (parse-int sides-str) )
+          sides (parse-int sides-str)
           plus-minus (if (= "-" plus-minus-str)
                        -1
                        1)
@@ -57,7 +57,7 @@
   (if-let [[_ num-str sides-str plus-minus-str mod-str :as match]
            (re-matches dice-regex dice-text)]
     (let [num (or (parse-int num-str) 1)
-          sides (or (parse-int sides-str))
+          sides (parse-int sides-str)
           plus-minus (if (= "-" plus-minus-str)
                        -1
                        +1)

--- a/src/cljc/orcpub/registration.cljc
+++ b/src/cljc/orcpub/registration.cljc
@@ -32,7 +32,7 @@
       ;;password-missing-special-character? (update :password conj "Password must have a least one of the following characters: !, @, #, $, %, ^, &, or *")
       password-too-short? (update :password conj "Password must be at least 6 characters"))))
 
-(def email-format #"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}")
+(def email-format #"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,64}")
 
 (defn bad-email? [email]
   (fails-match? email-format email))


### PR DESCRIPTION
Add length to 64 for suffix.
Fixes #504

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)