### PR TITLE
Resolve issues around building containers; missing dependencies.

### DIFF
--- a/docker/datomic/Dockerfile
+++ b/docker/datomic/Dockerfile
@@ -3,10 +3,9 @@ MAINTAINER daemonsthere@gmail.com
 
 ENV DATOMIC_VERSION 0.9.5703
 
-RUN wget https://my.datomic.com/downloads/free/${DATOMIC_VERSION} -qO /tmp/datomic.zip \
-  && unzip /tmp/datomic.zip \
-  && rm /tmp/datomic.zip \
-  && mv /datomic-free-${DATOMIC_VERSION} /datomic
+ADD /deploy/datomic-free-${DATOMIC_VERSION} /
+
+RUN mv /datomic-free-${DATOMIC_VERSION} datomic
 
 WORKDIR /datomic
 

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [re-frame "0.10.9"]
                  [reagent "0.7.0"]
                  [garden "1.3.2"]
-                 [org.apache.pdfbox/pdfbox "2.1.0-20170324.170253-831"]
+                 [org.apache.pdfbox/pdfbox "2.0.25"]
                  [io.pedestal/pedestal.service "0.5.1"]
                  [io.pedestal/pedestal.route "0.5.1"]
                  [io.pedestal/pedestal.jetty "0.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [re-frame "0.10.9"]
                  [reagent "0.7.0"]
                  [garden "1.3.2"]
-                 [org.apache.pdfbox/pdfbox "2.0.25"]
+                 [org.apache.pdfbox/pdfbox "2.1.0-20170324.170253-831"]
                  [io.pedestal/pedestal.service "0.5.1"]
                  [io.pedestal/pedestal.route "0.5.1"]
                  [io.pedestal/pedestal.jetty "0.5.1"]

--- a/src/clj/orcpub/pdf.clj
+++ b/src/clj/orcpub/pdf.clj
@@ -32,7 +32,7 @@
   (let [catalog (.getDocumentCatalog doc)
         form (.getAcroForm catalog)
         res (or (.getDefaultResources form) (PDResources.))]
-    (.setNeedAppearances form false)
+    (.setNeedAppearances form true)
     (.setDefaultResources form res)
     (doseq [[k v] fields]
       (try

--- a/src/clj/orcpub/pdf.clj
+++ b/src/clj/orcpub/pdf.clj
@@ -32,7 +32,7 @@
   (let [catalog (.getDocumentCatalog doc)
         form (.getAcroForm catalog)
         res (or (.getDefaultResources form) (PDResources.))]
-    (.setNeedAppearances form true)
+    (.setNeedAppearances form false)
     (.setDefaultResources form res)
     (doseq [[k v] fields]
       (try


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #549 and #539
Since Cognitect has ceased making datomic-free versions available, the current method of building the orcpub-datomic container is permanently broken. This is a workaround.
I've included a fix for the PDFBox (539) problem as well.
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation if necessary
  - [X] There is no commented out code in this PR.
  - [X] My changes generate no new warnings (check the console)