### PR TITLE
Ignore ./.lsp language server dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ env.sh
 *.crt
 *.key
 deploy/homebrew/*
+
+# As created by some LSP-protocol tooling, e.g. nvim-lsp
+.lsp


### PR DESCRIPTION
## Description:

This just ignores the `.lsp` dir in the top level director.

**Related issue (if applicable):** fixes #581.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)