### PR TITLE
Support loading jars from local `./lib` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pom.xml
 .lein-repl-history
 .lein-plugins/
 .lein-*
+.lsp
 .idea
 orcpub.iml
 profiles.clj

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,11 @@
   :repositories [["apache" "http://repository.apache.org/snapshots/"]
                  ["my.datomic.com" {:url "https://my.datomic.com/repo"
                                     :username [:gpg :env]
-                                    :password [:gpg :env]}]]
+                                    :password [:gpg :env]}]
+                 ["local" {:url "file:lib"
+                           :checksum :ignore
+                           :releases {:checksum :ignore}}]
+                 ]
   :mirrors {"apache" {:url "https://repository.apache.org/snapshots/"}}
 
   :dependencies [[org.clojure/clojure "1.10.0"]
@@ -66,6 +70,7 @@
 
   :plugins [[lein-figwheel "0.5.19"]
             [lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]
+            [lein-localrepo "0.5.4"]
             [lein-garden "0.3.0"]
             [lein-environ "1.1.0"]
             [lein-cljfmt "0.6.8"]

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  ["my.datomic.com" {:url "https://my.datomic.com/repo"
                                     :username [:gpg :env]
                                     :password [:gpg :env]}]
+                 ; This allows us to seamlessly load jars from local disk.
                  ["local" {:url "file:lib"
                            :checksum :ignore
                            :releases {:checksum :ignore}}]


### PR DESCRIPTION
## Description:

`pdfbox` and its deps aren't available upstream anymore, but we include them directly in the `./lib` dir, presumably so that people can copy them into `~/.m2` themselves and get things working. This makes onboarding _extremely_ confusing for losers like myself that don't know anything about clojure or leiningen or are jvm novices in general.

This changes teaches `lein` to use `./lib` as a local repo and use the jars it finds there, ignoring any checksum related issues since we don't have checksums for these and it's very unlikely that they get corrupted while being copied locally anyway.

**Related issue (if applicable):** fixes #539 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)