### PR TITLE
Fix lint errors hidden by #539

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ pom.xml
 .lein-repl-history
 .lein-plugins/
 .lein-*
+.lsp
 .idea
 orcpub.iml
 profiles.clj

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ env.sh
 *.crt
 *.key
 deploy/homebrew/*
+
+# As created by some LSP-protocol tooling, e.g. nvim-lsp
+.lsp

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,11 @@
   :repositories [["apache" "http://repository.apache.org/snapshots/"]
                  ["my.datomic.com" {:url "https://my.datomic.com/repo"
                                     :username [:gpg :env]
-                                    :password [:gpg :env]}]]
+                                    :password [:gpg :env]}]
+                 ["local" {:url "file:lib"
+                           :checksum :ignore
+                           :releases {:checksum :ignore}}]
+                 ]
   :mirrors {"apache" {:url "https://repository.apache.org/snapshots/"}}
 
   :dependencies [[org.clojure/clojure "1.10.0"]
@@ -66,6 +70,7 @@
 
   :plugins [[lein-figwheel "0.5.19"]
             [lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]
+            [lein-localrepo "0.5.4"]
             [lein-garden "0.3.0"]
             [lein-environ "1.1.0"]
             [lein-cljfmt "0.6.8"]

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  ["my.datomic.com" {:url "https://my.datomic.com/repo"
                                     :username [:gpg :env]
                                     :password [:gpg :env]}]
+                 ; This allows us to seamlessly load jars from local disk.
                  ["local" {:url "file:lib"
                            :checksum :ignore
                            :releases {:checksum :ignore}}]

--- a/src/clj/orcpub/security.clj
+++ b/src/clj/orcpub/security.clj
@@ -81,6 +81,6 @@
           (>= 3)))
 
 (defn multiple-ip-attempts-to-same-account? [username]
-  multiple-ip-attempts-to-same-account-aux
+  (multiple-ip-attempts-to-same-account-aux
   username
-  @failed-login-attempts-by-username)
+  @failed-login-attempts-by-username))


### PR DESCRIPTION
## Description:

`lein lint` is pretty upset about the state of things in `src/clj/orcpub/security.clj`. I think this has been the case for awhile, but it was hidden by the broken build that #583 fixes.

With this PR, `lein lint` passes with no warnings.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)