### PR TITLE
- Fix Sculpt Spells' wording (cannot target self)

### DIFF
--- a/src/cljc/orcpub/dnd/e5/classes.cljc
+++ b/src/cljc/orcpub/dnd/e5/classes.cljc
@@ -2414,7 +2414,7 @@
                            {:level 2
                             :name "Sculpt Spells"
                             :page 117
-                            :summary "can choose up to 1 + spell's level creatures to automatically save against your evocation spells and take no damage"}
+                            :summary "can choose up to 1 + spell's level creatures (other than self) to automatically save against your evocation spells and take no damage"}
                            {:level 6
                             :name "Potent Cantrip"
                             :page 117

--- a/src/cljc/orcpub/dnd/e5/classes.cljc
+++ b/src/cljc/orcpub/dnd/e5/classes.cljc
@@ -2414,7 +2414,7 @@
                            {:level 2
                             :name "Sculpt Spells"
                             :page 117
-                            :summary "can choose up to 1 + spell's level creatures (other than self) to automatically save against your evocation spells and take no damage"}
+                            :summary "When you cast an evocation spell that affects other creatures that you can see, you can choose a number of them equal to 1 + the spell’s level. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save."}
                            {:level 6
                             :name "Potent Cantrip"
                             :page 117


### PR DESCRIPTION
The current wording on Sculpt Spells
`can choose up to 1 + spell's level creatures to automatically save against your evocation spells and take no damage`
does not make it clear that it cannot be used on self. The change should make that clear
`can choose up to 1 + spell's level creatures **(other than self)** to automatically save against your evocation spells and take no damage
`

For reference, here is the [roll20 entry](https://roll20.net/compendium/dnd5e/School%20of%20Evocation#content) on this with the relevant bits highlighted:
```
Sculpt Spells
Beginning at 2nd level, you can create pockets of relative safety within the effects of your evocation spells. When you cast an evocation spell that affects **other creatures** that you can see, you can choose a number **of them** equal to 1 + the spell’s level. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save.
```

