### PR TITLE
Fix: make lower-casing nil-safe in common.cljc 

### DIFF
--- a/src/cljc/orcpub/common.cljc
+++ b/src/cljc/orcpub/common.cljc
@@ -179,11 +179,18 @@
 
 ;; Case Insensitive `sort-by`
 (defn aloof-sort-by [sorter coll]
-  (sort-by (comp s/lower-case sorter) coll)
+  (sort-by (fn [x]
+             (let [v (sorter x)]
+               (cond
+                 (string? v) (s/lower-case v)
+                 (nil? v) ""
+                 :else (s/lower-case (str v)))))
+           coll)
   )
 
 (defn ->kebab-case [s]
-  (-> s
-      ;; Insert hyphen before each capital letter, but not at the start.
-      (s/replace #"([A-Z])" "-$1")
-      .toLowerCase))
+  (when (string? s)
+    (-> s
+        ;; Insert hyphen before each capital letter, but not at the start.
+        (s/replace #"([A-Z])" "-$1")
+        (s/lower-case))))


### PR DESCRIPTION
- aloof-sort-by: handle nils and non-strings before lower-casing
- ->kebab-case: guard for strings and use clojure.string/lower-case

Prevents TypeError: "toLowerCase" of null in cljs paths.

## Description:

**Related issue (if applicable):** fixes #<issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)