### PR TITLE
Fix URL string when fetching homebrew content

### DIFF
--- a/src/clj/orcpub/index.clj
+++ b/src/clj/orcpub/index.clj
@@ -134,7 +134,7 @@ html {
 
       [:script
        "const protocol = window.location.protocol;
-        const apiUrl = `${protocol}://${window.location.host}`;
+        const apiUrl = `${protocol}//${window.location.host}`;
         const pluginUrl = `${apiUrl}/homebrew.orcbrew`;
         
         let plugins = localStorage.getItem('plugins');


### PR DESCRIPTION
## Description:
Small change to account for the fact that window.location.protocol always contains a colon, ie "https:" not "https".
This produced an error in fetching "homebrew.orcbrew" as the URL was malformed.
Remove the colon fixes this. This is the case for all browsers and systems.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)