### PR TITLE
Fixes #633, #572, #552, #276 - dropdown refresh bug, checkbox snapback, pdf custom item display

### DIFF
--- a/src/clj/orcpub/db/schema.clj
+++ b/src/clj/orcpub/db/schema.clj
@@ -369,6 +369,7 @@
    (map
     bool-prop-no-history
     [::weapon5e/special?
+     ::weapon5e/loading?
      ::weapon5e/melee?
      ::weapon5e/ranged?
      ::weapon5e/heavy?

--- a/src/cljc/orcpub/components.cljc
+++ b/src/cljc/orcpub/components.cljc
@@ -20,20 +20,29 @@
    {:value key}
    name])
 
+;; Form-2 component: local atom tracks the dropdown value so that after the
+;; on-change handler fires we can immediately reset the <select> back to the
+;; placeholder.  This prevents the dropdown from appearing "stuck" on the last
+;; selected item after adding it to the list.
 (defn selection-adder [values on-change]
-  [:select.builder-option.builder-option-dropdown
-   {:value ""
-    :on-change on-change}
-   [:option.builder-dropdown-item
-    {:value ""
-     :disabled true}
-    "<select to add>"]
-   (doall
-    (map
-     (fn [{:keys [key name]}]
-       ^{:key key}
-       [selection-item key name false])
-     values))])
+  (let [selected-value (atom "")]
+    (fn [values on-change]
+      [:select.builder-option.builder-option-dropdown
+       {:value @selected-value
+        :on-change (fn [e]
+                     (let [v (-> e .-target .-value)]
+                       (on-change e)
+                       (reset! selected-value "")))}
+       [:option.builder-dropdown-item
+        {:value ""
+         :disabled true}
+        "<select to add>"]
+       (doall
+        (map
+         (fn [{:keys [key name]}]
+           ^{:key key}
+           [selection-item key name false])
+         values))])))
 
 (defn selection [values on-change selected-value]
   [:select

--- a/src/cljc/orcpub/components.cljc
+++ b/src/cljc/orcpub/components.cljc
@@ -20,10 +20,7 @@
    {:value key}
    name])
 
-;; Form-2 component: local atom tracks the dropdown value so that after the
-;; on-change handler fires we can immediately reset the <select> back to the
-;; placeholder.  This prevents the dropdown from appearing "stuck" on the last
-;; selected item after adding it to the list.
+;; Form-2 component: resets <select> to placeholder after each on-change fires.
 (defn selection-adder [values on-change]
   (let [selected-value (atom "")]
     (fn [values on-change]

--- a/src/cljc/orcpub/dnd/e5/magic_items.cljc
+++ b/src/cljc/orcpub/dnd/e5/magic_items.cljc
@@ -2951,7 +2951,9 @@ The boots regain 2 hours of flying capability for every 12 hours they aren’t i
    weapons5e/ammunition))
 
 (defn add-key [item]
-  (assoc item :key (common/name-to-kw (name-key item))))
+  (assoc item
+         :key (common/name-to-kw (name-key item))
+         :name (name-key item)))
 
 (def weapon-subtypes
   #{:axe :sword :staff})

--- a/src/cljc/orcpub/dnd/e5/magic_items.cljc
+++ b/src/cljc/orcpub/dnd/e5/magic_items.cljc
@@ -230,6 +230,7 @@
                     ::weapons5e/range
                     ::weapons5e/versatile
                     ::weapons5e/special?
+                    ::weapons5e/loading?
                     ::weapons5e/melee?
                     ::weapons5e/ranged?
                     ::weapons5e/heavy?
@@ -3161,6 +3162,8 @@ The boots regain 2 hours of flying capability for every 12 hours they aren’t i
           ::weapons5e/heavy?
           ::weapons5e/light?
           ::weapons5e/ammunition?
+          ::weapons5e/special?
+          ::weapons5e/loading?
           ::weapons5e/damage-die-count
           ::weapons5e/damage-die
           ::weapons5e/versatile
@@ -3174,19 +3177,24 @@ The boots regain 2 hours of flying capability for every 12 hours they aren’t i
 ;; switching to :other (Custom) so the view doesn't need to dispatch
 ;; defaults during render.
 (defn apply-subtype-toggle [item type]
-  (remove-custom-weapon-fields
-   (case type
-     :other (-> item
-                (assoc ::subtypes #{:other})
-                (assoc ::damage-die-count 1)
-                (assoc ::damage-die 4)
-                (assoc ::weapon-type :simple)
-                (assoc ::melee-ranged :melee))
-     :all (assoc item ::subtypes #{:all})
-     (update item
-             ::subtypes
-             (fn [s]
-               (let [clean (disj (or s #{}) :other :all)]
-                 (if (get clean type)
-                   (disj clean type)
-                   (conj clean type))))))))
+  (case type
+    :other (-> item
+               remove-custom-weapon-fields
+               (assoc ::subtypes #{:other})
+               (assoc ::weapons5e/damage-die-count 1)
+               (assoc ::weapons5e/damage-die 4)
+               (assoc ::weapons5e/type :simple)
+               (assoc ::weapons5e/damage-type :bludgeoning)
+               (assoc ::weapons5e/melee? true)
+               (assoc ::weapons5e/ranged? false))
+    :all (-> item
+             remove-custom-weapon-fields
+             (assoc ::subtypes #{:all}))
+    (-> item
+        remove-custom-weapon-fields
+        (update ::subtypes
+                (fn [s]
+                  (let [clean (disj (or s #{}) :other :all)]
+                    (if (get clean type)
+                      (disj clean type)
+                      (conj clean type))))))))

--- a/src/cljc/orcpub/dnd/e5/magic_items.cljc
+++ b/src/cljc/orcpub/dnd/e5/magic_items.cljc
@@ -3149,3 +3149,44 @@ The boots regain 2 hours of flying capability for every 12 hours they aren’t i
 
 (defn equipped-armor-details [armor]
   (equipped-items-details armor all-armor-map))
+
+;; Strip base-weapon detail keys that only apply to custom (:other) weapons.
+(defn remove-custom-weapon-fields [item]
+  (dissoc item
+          ::weapons5e/finesse?
+          ::weapons5e/versatile?
+          ::weapons5e/reach?
+          ::weapons5e/two-handed?
+          ::weapons5e/thrown?
+          ::weapons5e/heavy?
+          ::weapons5e/light?
+          ::weapons5e/ammunition?
+          ::weapons5e/damage-die-count
+          ::weapons5e/damage-die
+          ::weapons5e/versatile
+          ::weapons5e/melee?
+          ::weapons5e/ranged?
+          ::weapons5e/type
+          ::weapons5e/range
+          ::weapons5e/damage-type))
+
+;; Apply a subtype toggle to an item. Initialises sane defaults when
+;; switching to :other (Custom) so the view doesn't need to dispatch
+;; defaults during render.
+(defn apply-subtype-toggle [item type]
+  (remove-custom-weapon-fields
+   (case type
+     :other (-> item
+                (assoc ::subtypes #{:other})
+                (assoc ::damage-die-count 1)
+                (assoc ::damage-die 4)
+                (assoc ::weapon-type :simple)
+                (assoc ::melee-ranged :melee))
+     :all (assoc item ::subtypes #{:all})
+     (update item
+             ::subtypes
+             (fn [s]
+               (let [clean (disj (or s #{}) :other :all)]
+                 (if (get clean type)
+                   (disj clean type)
+                   (conj clean type))))))))

--- a/src/cljc/orcpub/dnd/e5/weapons.cljc
+++ b/src/cljc/orcpub/dnd/e5/weapons.cljc
@@ -12,6 +12,7 @@
     :key :crossbow-light
     ::two-handed? true
     ::ammunition? true
+    ::loading? true
     ::link "https://en.wikipedia.org/wiki/Crossbow"}
    {::ranged? true,
     :key :dart,
@@ -332,6 +333,7 @@
     ::ranged? true,
     ::range {::min 25, ::max 100},
     ::ammunition? true
+    ::loading? true
     :key :blowgun}
    {:name "Crossbow, hand",
     ::damage-type :piercing,
@@ -341,6 +343,7 @@
     ::ranged? true,
     ::range {::min 30, ::max 120},
     ::ammunition? true
+    ::loading? true
     ::light? true
     :key :crossbow-hand}
    {:name "Crossbow, heavy",
@@ -353,6 +356,7 @@
     ::range {::min 100, ::max 400},
     :key :crossbow-heavy
     ::ammunition? true
+    ::loading? true
     ::two-handed? true}
    {:name "Longbow",
     ::damage-type :piercing,
@@ -383,6 +387,7 @@
     ::heavy? true,
     ::range {::min 30, ::max 90},
     :key :firearm-hand
+    ::loading? true
     ::two-handed? false}
    {:name "Firearm, Burst (DMV)",
     ::damage-type :piercing,
@@ -403,6 +408,7 @@
     ::heavy? true,
     ::range {::min 60, ::max 120},
     :key :firearm-long
+    ::loading? true
     ::two-handed? true}])
 
 (def ammunition

--- a/src/cljc/orcpub/pdf_spec.cljc
+++ b/src/cljc/orcpub/pdf_spec.cljc
@@ -158,7 +158,8 @@
 (def coin-keys [:cp :sp :ep :gp :pp])
 
 (defn equipment-fields [built-char]
-  (let [equipment (es/entity-val built-char :equipment)
+  (let [equipment-map (merge mi5e/all-equipment-map @(subscribe [::mi5e/all-magic-items-map]))
+        equipment (es/entity-val built-char :equipment)
         armor (es/entity-val built-char :armor)
         magic-armor (es/entity-val built-char :magic-armor)
         magic-items (es/entity-val built-char :magic-items)
@@ -188,8 +189,8 @@
                    (map
                    (fn [[kw {count ::char-equip5e/quantity}]]
                      (if (> count 1)
-                       (str (disp5e/equipment-name mi5e/all-equipment-map kw) " x" count )
-                       (str (disp5e/equipment-name mi5e/all-equipment-map kw))
+                       (str (disp5e/equipment-name equipment-map kw) " x" count )
+                       (str (disp5e/equipment-name equipment-map kw))
                        )
                      )
                    (filter
@@ -199,7 +200,7 @@
                   "\n"
                   (map
                    (fn [[kw {count ::char-equip5e/quantity}]]
-                     (str (disp5e/equipment-name mi5e/all-equipment-map kw) " (" count ")"))
+                     (str (disp5e/equipment-name equipment-map kw) " (" count ")"))
                    (merge
                     (apply dissoc treasure coin-keys)
                     unequipped-items)))})))

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -3772,7 +3772,16 @@
  (fn [item [_ type]]
    (remove-custom-weapon-fields
     (case type
-      :other (assoc item ::mi/subtypes #{:other})
+      ;; When switching to Custom (:other), initialise weapon fields to sane
+      ;; defaults here in the event handler instead of during view render.
+      ;; Setting them during render caused the dropdowns to reset on every
+      ;; re-render, making user selection impossible.
+      :other (-> item
+                 (assoc ::mi/subtypes #{:other})
+                 (assoc ::mi/damage-die-count 1)
+                 (assoc ::mi/damage-die 4)
+                 (assoc ::mi/weapon-type :simple)
+                 (assoc ::mi/melee-ranged :melee))
       :all (assoc item ::mi/subtypes #{:all})
       (update item
               ::mi/subtypes

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -440,8 +440,14 @@
  :item-save-success
  (fn [{:keys [db]} [_ response]]
    (let [strict-item (:body response)
-         item (mi/to-internal-item strict-item)]
-     {:dispatch-n [[:show-message "Your item has been saved."]
+         item (mi/to-internal-item strict-item)
+         item-id (:db/id strict-item)
+         existing-items (::mi/custom-items db)
+         updated-items (if (some #(= item-id (:db/id %)) existing-items)
+                         (mapv #(if (= item-id (:db/id %)) strict-item %) existing-items)
+                         (conj (vec existing-items) strict-item))]
+     {:db (assoc db ::mi/custom-items updated-items)
+      :dispatch-n [[:show-message "Your item has been saved."]
                    [::mi/set-item item]]})))
 
 (reg-event-fx
@@ -3071,6 +3077,18 @@
  item-interceptors
  (fn [item _]
    (update item ::weapons/ammunition? not)))
+
+(reg-event-db
+ ::mi/toggle-item-special?
+ item-interceptors
+ (fn [item _]
+   (update item ::weapons/special? not)))
+
+(reg-event-db
+ ::mi/toggle-item-loading?
+ item-interceptors
+ (fn [item _]
+   (update item ::weapons/loading? not)))
 
 (reg-event-db
  ::mi/toggle-item-versatile?

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -3747,47 +3747,11 @@
                   ability-kw
                   value)))
 
-(defn remove-custom-weapon-fields [item]
-  (dissoc item
-          ::weapons/finesse?
-          ::weapons/versatile?
-          ::weapons/reach?
-          ::weapons/two-handed?
-          ::weapons/thrown?
-          ::weapons/heavy?
-          ::weapons/light?
-          ::weapons/ammunition?
-          ::weapons/damage-die-count
-          ::weapons/damage-die
-          ::weapons/versatile
-          ::weapons/melee?
-          ::weapons/ranged?
-          ::weapons/type
-          ::weapons/range
-          ::weapons/damage-type))
-
 (reg-event-db
  ::mi/toggle-subtype
  item-interceptors
  (fn [item [_ type]]
-   (remove-custom-weapon-fields
-    (case type
-      ;; When switching to Custom (:other), initialise weapon fields to sane
-      ;; defaults here in the event handler instead of during view render.
-      ;; Setting them during render caused the dropdowns to reset on every
-      ;; re-render, making user selection impossible.
-      :other (-> item
-                 (assoc ::mi/subtypes #{:other})
-                 (assoc ::mi/damage-die-count 1)
-                 (assoc ::mi/damage-die 4)
-                 (assoc ::mi/weapon-type :simple)
-                 (assoc ::mi/melee-ranged :melee))
-      :all (assoc item ::mi/subtypes #{:all})
-      (update item
-              ::mi/subtypes
-              #(as-> % $
-                 (disj $ :other :all)
-                 (toggle-set type $)))))))
+   (mi/apply-subtype-toggle item type)))
 
 (reg-event-fx
  ::char5e/open-character

--- a/src/cljs/orcpub/dnd/e5/subs.cljs
+++ b/src/cljs/orcpub/dnd/e5/subs.cljs
@@ -1106,6 +1106,18 @@
    (get item ::weapon5e/ammunition?)))
 
 (reg-sub
+ ::mi5e/item-special?
+ :<- [::mi5e/builder-item]
+ (fn [item _]
+   (get item ::weapon5e/special?)))
+
+(reg-sub
+ ::mi5e/item-loading?
+ :<- [::mi5e/builder-item]
+ (fn [item _]
+   (get item ::weapon5e/loading?)))
+
+(reg-sub
  ::mi5e/item-versatile?
  :<- [::mi5e/builder-item]
  (fn [item _]

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -3844,13 +3844,6 @@
             )
             )))])]]
      (when other?
-       ;;;batch-set multiple default values
-       (doseq [evt [[::mi/set-item-damage-die-count 1]
-                    [::mi/set-item-damage-die       4]
-                    [::mi/set-item-weapon-type      :simple]
-                    [::mi/set-item-melee-ranged     :melee]]
-               ]
-         (dispatch evt))
        [:div.main-text-color.m-b-10.m-t-10
         [:span.f-s-18.f-w-b "Base Weapon Details"]
         [:div.flex.flex-wrap.m-t-10

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -3870,7 +3870,13 @@
           [labeled-checkbox "Light?" @(subscribe [::mi/item-light?])]]
          [:div.m-l-10
           {:on-click (make-event-handler ::mi/toggle-item-ammunition?)}
-          [labeled-checkbox "Ammunition?" @(subscribe [::mi/item-ammunition?])]]]
+          [labeled-checkbox "Ammunition?" @(subscribe [::mi/item-ammunition?])]]
+         [:div.m-l-10
+          {:on-click (make-event-handler ::mi/toggle-item-special?)}
+          [labeled-checkbox "Special?" @(subscribe [::mi/item-special?])]]
+         [:div.m-l-10
+          {:on-click (make-event-handler ::mi/toggle-item-loading?)}
+          [labeled-checkbox "Loading?" @(subscribe [::mi/item-loading?])]]]
         [:div.flex.flex-wrap
          [:div.m-t-10
           [labeled-dropdown

--- a/test/cljc/orcpub/dnd/e5/magic_items_test.clj
+++ b/test/cljc/orcpub/dnd/e5/magic_items_test.clj
@@ -153,6 +153,8 @@
                 ::weapons5e/heavy? true
                 ::weapons5e/light? false
                 ::weapons5e/ammunition? false
+                ::weapons5e/special? true
+                ::weapons5e/loading? true
                 ::weapons5e/damage-die-count 2
                 ::weapons5e/damage-die 6
                 ::weapons5e/versatile 8
@@ -174,10 +176,12 @@
                 ::weapons5e/finesse? true}
           result (mi/apply-subtype-toggle item :other)]
       (is (= #{:other} (::mi/subtypes result)))
-      (is (= 1 (::mi/damage-die-count result)))
-      (is (= 4 (::mi/damage-die result)))
-      (is (= :simple (::mi/weapon-type result)))
-      (is (= :melee (::mi/melee-ranged result)))
+      (is (= 1 (::weapons5e/damage-die-count result)))
+      (is (= 4 (::weapons5e/damage-die result)))
+      (is (= :simple (::weapons5e/type result)))
+      (is (= :bludgeoning (::weapons5e/damage-type result)))
+      (is (true? (::weapons5e/melee? result)))
+      (is (false? (::weapons5e/ranged? result)))
       (is (nil? (::weapons5e/finesse? result))
           "base weapon keys should be stripped")))
   (testing ":other is idempotent"
@@ -204,3 +208,54 @@
           result (mi/apply-subtype-toggle item :sword)]
       (is (= #{:sword} (::mi/subtypes result)))
       (is (not (contains? (::mi/subtypes result) :other))))))
+
+(deftest test-custom-weapon-round-trip
+  (testing "custom weapon defaults survive from-internal-item serialization"
+    (let [builder-item (-> {::mi/name "Test Blade"
+                            ::mi/type :weapon
+                            ::mi/rarity :uncommon}
+                           (mi/apply-subtype-toggle :other))
+          serialized (mi/from-internal-item builder-item)]
+      (is (= "Test Blade" (::mi/name serialized)))
+      (is (= :weapon (::mi/type serialized)))
+      (is (= :uncommon (::mi/rarity serialized)))
+      (is (= #{:other} (::mi/subtypes serialized)))
+      (is (= 1 (::weapons5e/damage-die-count serialized))
+          "damage die count must survive serialization")
+      (is (= 4 (::weapons5e/damage-die serialized))
+          "damage die must survive serialization")
+      (is (= :simple (::weapons5e/type serialized))
+          "weapon type must survive serialization")
+      (is (= :bludgeoning (::weapons5e/damage-type serialized))
+          "damage type must survive serialization")
+      (is (true? (::weapons5e/melee? serialized))
+          "melee flag must survive serialization")))
+  (testing "custom weapon with user overrides round-trips correctly"
+    (let [builder-item (-> {::mi/name "Fire Lance"
+                            ::mi/type :weapon
+                            ::mi/rarity :rare}
+                           (mi/apply-subtype-toggle :other)
+                           (assoc ::weapons5e/damage-die-count 2)
+                           (assoc ::weapons5e/damage-die 8)
+                           (assoc ::weapons5e/type :martial)
+                           (assoc ::weapons5e/damage-type :fire)
+                           (assoc ::weapons5e/melee? false)
+                           (assoc ::weapons5e/ranged? true))
+          serialized (mi/from-internal-item builder-item)]
+      (is (= 2 (::weapons5e/damage-die-count serialized)))
+      (is (= 8 (::weapons5e/damage-die serialized)))
+      (is (= :martial (::weapons5e/type serialized)))
+      (is (= :fire (::weapons5e/damage-type serialized)))
+      (is (true? (::weapons5e/ranged? serialized)))))
+  (testing "special and loading properties survive round-trip"
+    (let [builder-item (-> {::mi/name "Net Launcher"
+                            ::mi/type :weapon
+                            ::mi/rarity :common}
+                           (mi/apply-subtype-toggle :other)
+                           (assoc ::weapons5e/special? true)
+                           (assoc ::weapons5e/loading? true))
+          serialized (mi/from-internal-item builder-item)]
+      (is (true? (::weapons5e/special? serialized))
+          "special? must survive serialization")
+      (is (true? (::weapons5e/loading? serialized))
+          "loading? must survive serialization"))))

--- a/test/cljc/orcpub/dnd/e5/magic_items_test.clj
+++ b/test/cljc/orcpub/dnd/e5/magic_items_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [testing deftest is]]
             [orcpub.dnd.e5.magic-items :as mi]
             [orcpub.dnd.e5.character :as char]
+            [orcpub.dnd.e5.weapons :as weapons5e]
             [orcpub.modifiers :as mod]
             [orcpub.dnd.e5.modifiers :as mod5e]))
 
@@ -140,3 +141,66 @@
                 ::mi/type :armor
                 ::mi/item-subtype (constantly false)}]
       (is (thrown? IllegalArgumentException (mi/expand-armor item))))))
+
+(deftest test-remove-custom-weapon-fields
+  (testing "strips all weapon-specific keys"
+    (let [item {::mi/name "Test Weapon"
+                ::weapons5e/finesse? true
+                ::weapons5e/versatile? true
+                ::weapons5e/reach? false
+                ::weapons5e/two-handed? true
+                ::weapons5e/thrown? false
+                ::weapons5e/heavy? true
+                ::weapons5e/light? false
+                ::weapons5e/ammunition? false
+                ::weapons5e/damage-die-count 2
+                ::weapons5e/damage-die 6
+                ::weapons5e/versatile 8
+                ::weapons5e/melee? true
+                ::weapons5e/ranged? false
+                ::weapons5e/type :martial
+                ::weapons5e/range [20 60]
+                ::weapons5e/damage-type :slashing}
+          result (mi/remove-custom-weapon-fields item)]
+      (is (= {::mi/name "Test Weapon"} result))))
+  (testing "preserves item when no weapon keys present"
+    (let [item {::mi/name "Ring" ::mi/type :ring}
+          result (mi/remove-custom-weapon-fields item)]
+      (is (= item result)))))
+
+(deftest test-apply-subtype-toggle--custom
+  (testing ":other sets custom defaults and strips weapon fields"
+    (let [item {::mi/name "My Sword"
+                ::weapons5e/finesse? true}
+          result (mi/apply-subtype-toggle item :other)]
+      (is (= #{:other} (::mi/subtypes result)))
+      (is (= 1 (::mi/damage-die-count result)))
+      (is (= 4 (::mi/damage-die result)))
+      (is (= :simple (::mi/weapon-type result)))
+      (is (= :melee (::mi/melee-ranged result)))
+      (is (nil? (::weapons5e/finesse? result))
+          "base weapon keys should be stripped")))
+  (testing ":other is idempotent"
+    (let [item {}
+          r1 (mi/apply-subtype-toggle item :other)
+          r2 (mi/apply-subtype-toggle r1 :other)]
+      (is (= r1 r2)))))
+
+(deftest test-apply-subtype-toggle--all
+  (testing ":all sets subtypes to #{:all}"
+    (let [result (mi/apply-subtype-toggle {} :all)]
+      (is (= #{:all} (::mi/subtypes result))))))
+
+(deftest test-apply-subtype-toggle--named
+  (testing "adds a named subtype"
+    (let [result (mi/apply-subtype-toggle {} :sword)]
+      (is (= #{:sword} (::mi/subtypes result)))))
+  (testing "toggles off an existing subtype"
+    (let [item {::mi/subtypes #{:sword}}
+          result (mi/apply-subtype-toggle item :sword)]
+      (is (= #{} (::mi/subtypes result)))))
+  (testing "clears :other/:all when toggling a named subtype"
+    (let [item {::mi/subtypes #{:other}}
+          result (mi/apply-subtype-toggle item :sword)]
+      (is (= #{:sword} (::mi/subtypes result)))
+      (is (not (contains? (::mi/subtypes result) :other))))))


### PR DESCRIPTION
## Description:

**Related issue (if applicable):**
FIXES #633 
FIXES #572
FIXES #552 
FIXES #276 

FINALLY fixes the value selection for custom weapon dropdowns (damage die, weapon type, melee/ranged). Fixes immediately snap back to its default because the defaults were being re-dispatched on every render cycle. Beyond that, the values that did get set were written to the wrong namespace keys, so they were silently dropped.

Fixes:

+ Dropdown reset loop - Default values are now applied once when "Custom" is first selected, not on every re-render. The selection component uses local atom to reset the placeholder after each pick.
+ Wrong namespace keys - apply-subtype-toggle changed form `::mi/ keys` to `::weapons5e/ keys`. Custom weapon properties now work correctly.
+ Added missing weapon properties - Added `Special` and `Loading` checkboxes to the builder; updated existing weapons (crossbows, blowgun, firearms) per SRDrules.
+ PDF export displays custom items - magic item maps should properly merge now. PDF fields were only looking up names from the base equipment map, so magic items showed up as keywords like `:flame-tongue` instead of "Flame Tongue". `add-key` now properly populates `:name` so custom items resolve correctly.
+ More Tests - Moved `remove-custom-weapon-fields` and `apply-subtype-toggle` to shared .cljc so they can be tested from JVM. Added tests covering field stripping, default application, and subtype toggling.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)
  