### PR TITLE
Character folders

### DIFF
--- a/src/clj/orcpub/db/schema.clj
+++ b/src/clj/orcpub/db/schema.clj
@@ -4,6 +4,7 @@
             [orcpub.dnd.e5.character :as char5e]
             [orcpub.dnd.e5.units :as units5e]
             [orcpub.dnd.e5.party :as party5e]
+            [orcpub.dnd.e5.folder :as folder5e]
             [orcpub.dnd.e5.magic-items :as mi5e]
             [orcpub.dnd.e5.weapons :as weapon5e]
             [orcpub.dnd.e5.spells :as spells5e]
@@ -312,6 +313,17 @@
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/many}])
 
+(def folder-schema
+  [{:db/ident ::folder5e/owner
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident ::folder5e/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident ::folder5e/character-ids
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/many}])
+
 (def character-equipment-schema
   (concat
    [(string-prop ::char-equip-5e/name)
@@ -389,5 +401,6 @@
    character-equipment-schema
    features-used-schema
    party-schema
+   folder-schema
    magic-item-schema
    weapon-schema))

--- a/src/clj/orcpub/routes.clj
+++ b/src/clj/orcpub/routes.clj
@@ -40,6 +40,7 @@
             [orcpub.entity :as entity]
             [orcpub.security :as security]
             [orcpub.routes.party :as party]
+            [orcpub.routes.folder :as folder]
             [orcpub.oauth :as oauth]
             [hiccup.page :as page]
             [environ.core :as environ]
@@ -160,6 +161,22 @@
               (if (= (:user identity) party-owner)
                 context
                 (terminate-request context 401 "You don't own this party"))))})
+
+(defn folder-owner [db id]
+  (d/q '[:find ?owner .
+         :in $ ?id
+         :where [?id :orcpub.dnd.e5.folder/owner ?owner]]
+       db
+       id))
+
+(def check-folder-owner
+  {:name :check-folder-owner
+   :enter (fn [context]
+            (let [{:keys [identity db] {:keys [id]} :path-params} (:request context)
+                  folder-owner (folder-owner db id)]
+              (if (= (:user identity) folder-owner)
+                context
+                (terminate-request context 401 "You don't own this folder"))))})
 
 (defn redirect [route-key]
   (ring-resp/redirect (route-map/path-for route-key)))
@@ -1063,6 +1080,17 @@
         {:post `party/add-character}]
        [(route-map/path-for route-map/dnd-e5-char-party-character-route :id ":id" :character-id ":character-id") ^:interceptors [check-auth parse-id check-party-owner]
         {:delete `party/remove-character}]
+       [(route-map/path-for route-map/dnd-e5-char-folders-route) ^:interceptors [check-auth]
+        {:post `folder/create-folder
+         :get `folder/folders}]
+       [(route-map/path-for route-map/dnd-e5-char-folder-route :id ":id") ^:interceptors [check-auth parse-id check-folder-owner]
+        {:delete `folder/delete-folder}]
+       [(route-map/path-for route-map/dnd-e5-char-folder-name-route :id ":id") ^:interceptors [check-auth parse-id check-folder-owner]
+        {:put `folder/update-folder-name}]
+       [(route-map/path-for route-map/dnd-e5-char-folder-characters-route :id ":id") ^:interceptors [check-auth parse-id check-folder-owner]
+        {:post `folder/add-character}]
+       [(route-map/path-for route-map/dnd-e5-char-folder-character-route :id ":id" :character-id ":character-id") ^:interceptors [check-auth parse-id check-folder-owner]
+        {:delete `folder/remove-character}]
        [(route-map/path-for route-map/login-route)
         {:post `login}]
        [(route-map/path-for route-map/character-pdf-route)

--- a/src/clj/orcpub/routes/folder.clj
+++ b/src/clj/orcpub/routes/folder.clj
@@ -1,0 +1,57 @@
+(ns orcpub.routes.folder
+  (:require [datomic.api :as d]
+            [orcpub.dnd.e5.folder :as folder]
+            [orcpub.entity.strict :as se]))
+
+(def pull-folder
+  [:db/id ::folder/name {::folder/character-ids [:db/id ::se/owner ::se/summary]}])
+
+(defn create-folder [{:keys [conn identity] folder-data :transit-params}]
+  (let [username (:user identity)
+        result @(d/transact conn [(assoc folder-data ::folder/owner username)])
+        new-id (-> result :tempids first val)]
+    {:status 200 :body (d/pull (d/db conn) '[*] new-id)}))
+
+(defn folders [{:keys [db identity]}]
+  (let [username (:user identity)
+        result (d/q [:find `(~'pull ~'?e ~pull-folder)
+                     :in '$ '?username
+                     :where ['?e ::folder/owner '?username]]
+                    db username)
+        mapped (map (fn [[f]]
+                      (update f ::folder/character-ids
+                              (fn [chars]
+                                (map (fn [{:keys [:db/id ::se/owner ::se/summary]}]
+                                       (assoc summary :db/id id ::se/owner owner))
+                                     chars))))
+                    result)]
+    {:status 200 :body mapped}))
+
+(defn update-folder-name [{:keys [conn]
+                           folder-name :transit-params
+                           {:keys [id]} :path-params}]
+  @(d/transact conn [{:db/id id ::folder/name folder-name}])
+  {:status 200 :body (d/pull (d/db conn) pull-folder id)})
+
+(defn add-character [{:keys [db conn]
+                      character-id :transit-params
+                      {:keys [id]} :path-params}]
+  ;; Enforce at-most-one-folder: retract from existing folder first
+  (when-let [existing-id (d/q '[:find ?f .
+                                 :in $ ?char
+                                 :where [?f :orcpub.dnd.e5.folder/character-ids ?char]]
+                               db character-id)]
+    @(d/transact conn [[:db/retract existing-id ::folder/character-ids character-id]]))
+  @(d/transact conn [{:db/id id ::folder/character-ids character-id}])
+  {:status 200 :body (d/pull (d/db conn) '[*] id)})
+
+(defn remove-character [{:keys [conn]
+                         {:keys [id character-id]} :path-params}]
+  @(d/transact conn [[:db/retract id ::folder/character-ids (Long/parseLong character-id)]])
+  {:status 200 :body (d/pull (d/db conn) '[*] id)})
+
+(defn delete-folder [{:keys [conn]
+                      {:keys [id]} :path-params}]
+  ;; retractEntity removes only the folder entity; referenced character entities are unaffected
+  @(d/transact conn [[:db/retractEntity id]])
+  {:status 200})

--- a/src/clj/orcpub/routes/folder.clj
+++ b/src/clj/orcpub/routes/folder.clj
@@ -7,8 +7,10 @@
   [:db/id ::folder/name {::folder/character-ids [:db/id ::se/owner ::se/summary]}])
 
 (defn create-folder [{:keys [conn identity] folder-data :transit-params}]
+  ;; Whitelist only ::folder/name from client data; owner is always server-set
   (let [username (:user identity)
-        result @(d/transact conn [(assoc folder-data ::folder/owner username)])
+        result @(d/transact conn [{::folder/name (::folder/name folder-data)
+                                   ::folder/owner username}])
         new-id (-> result :tempids first val)]
     {:status 200 :body (d/pull (d/db conn) '[*] new-id)}))
 

--- a/src/clj/orcpub/styles/core.clj
+++ b/src/clj/orcpub/styles/core.clj
@@ -1167,14 +1167,14 @@
       :align-items :center}]
 
     [:.checkbox
-     {:width "16px"
-      :height "16px"
+     {:width "12px"
+      :height "12px"
       :box-shadow "0 1px 0 0 #f0a100"
       :background-color :white
       :cursor :pointer}
 
      [:.fa-check
-      {:font-size "14px"
+      {:font-size "12px"
        :margin "1px"}]]
 
     [:.checkbox.checked.disabled

--- a/src/clj/orcpub/styles/core.clj
+++ b/src/clj/orcpub/styles/core.clj
@@ -1167,14 +1167,14 @@
       :align-items :center}]
 
     [:.checkbox
-     {:width "12px"
-      :height "12px"
+     {:width "16px"
+      :height "16px"
       :box-shadow "0 1px 0 0 #f0a100"
       :background-color :white
       :cursor :pointer}
 
      [:.fa-check
-      {:font-size "12px"
+      {:font-size "14px"
        :margin "1px"}]]
 
     [:.checkbox.checked.disabled
@@ -1183,6 +1183,39 @@
 
     [:.checkbox-text
      {:margin-left "5px"}]
+
+    ;; Character filter bar — scoped styles for dropdowns and checkboxes
+    [:.char-filter-bar
+     [:.filter-dropdown
+      {:position :absolute
+       :background-color "#313A4D"
+       :padding "6px 4px"
+       :top "100%"
+       :margin-top "4px"
+       :border "1px solid rgba(255,255,255,0.15)"
+       :border-radius "4px"
+       :max-height "300px"
+       :overflow-y :auto
+       :font-weight :normal
+       :font-size "14px"
+       :z-index 200
+       :box-shadow "0 4px 12px rgba(0,0,0,0.4)"}]
+     [:.filter-dropdown-item
+      {:padding "6px 10px"
+       :border-radius "3px"
+       :cursor :pointer}]
+     [:.filter-dropdown-item:hover
+      {:background-color "rgba(255,255,255,0.08)"}]
+     [:.checkbox
+      {:width "14px"
+       :height "14px"
+       :min-width "14px"
+       :flex-shrink 0}
+      [:.fa-check
+       {:font-size "12px"}]]
+     [:.flex.pointer
+      {:align-items :center
+       :gap "8px"}]]
 
     [:#selection-stepper
      {:transition "top 2s ease-in-out"

--- a/src/cljc/orcpub/components.cljc
+++ b/src/cljc/orcpub/components.cljc
@@ -3,17 +3,17 @@
             #?(:cljs [reagent.core :refer [atom]])))
 
 (defn checkbox [selected? disable?]
-  [:i.fa.fa-check.f-s-14.bg-white.b-color-gray.orange-shadow.pointer.b-1
+  [:i.fa.fa-check.f-s-14.bg-white.b-color-gray.orange-shadow.pointer.b-3
    {:class-name (str (if selected? "black slight-text-shadow" "white transparent")
                      " "
                      (if disable?
                        "opacity-5"))}])
 
 (defn labeled-checkbox [label selected? disabled? on-click]
-  [:div.flex.pointer
+  [:div.flex.pointer.align-items-c
    {:on-click on-click}
    [checkbox selected? disabled?]
-   [:span.m-l-5 label]])
+   [:span.m-l-5.align-items-c label]])
 
 (defn selection-item [key name selected?]
   [:option.builder-dropdown-item

--- a/src/cljc/orcpub/components.cljc
+++ b/src/cljc/orcpub/components.cljc
@@ -3,17 +3,17 @@
             #?(:cljs [reagent.core :refer [atom]])))
 
 (defn checkbox [selected? disable?]
-  [:i.fa.fa-check.f-s-14.bg-white.b-color-gray.orange-shadow.pointer.b-3
+  [:i.fa.fa-check.f-s-14.bg-white.b-color-gray.orange-shadow.pointer.b-1
    {:class-name (str (if selected? "black slight-text-shadow" "white transparent")
                      " "
                      (if disable?
                        "opacity-5"))}])
 
 (defn labeled-checkbox [label selected? disabled? on-click]
-  [:div.flex.pointer.align-items-c
+  [:div.flex.pointer
    {:on-click on-click}
    [checkbox selected? disabled?]
-   [:span.m-l-5.align-items-c label]])
+   [:span.m-l-5 label]])
 
 (defn selection-item [key name selected?]
   [:option.builder-dropdown-item

--- a/src/cljc/orcpub/dnd/e5/char_filter.cljc
+++ b/src/cljc/orcpub/dnd/e5/char_filter.cljc
@@ -1,0 +1,32 @@
+(ns orcpub.dnd.e5.char-filter
+  (:require [clojure.string :as s]
+            [orcpub.dnd.e5.character :as char5e]))
+
+(defn char-matches?
+  "Returns true if `char` satisfies all active filter criteria.
+
+   Filters:
+     name-filter      - string; blank = no filter, otherwise case-insensitive substring
+     level-filters    - set of ints; empty = no filter, any class level must be in set
+     class-filters    - set of strings; empty = no filter, any class name must be in set
+     has-portrait?    - nil = all, true = must have image-url, false = must not
+     has-faction-pic? - nil = all, true = must have faction-image-url, false = must not"
+  [char name-filter level-filters class-filters has-portrait? has-faction-pic?]
+  (and
+   (or (s/blank? name-filter)
+       (s/includes? (s/lower-case (or (::char5e/character-name char) ""))
+                    (s/lower-case name-filter)))
+   (or (empty? level-filters)
+       (some #(level-filters (::char5e/level %)) (::char5e/classes char)))
+   (or (empty? class-filters)
+       (some #(class-filters (::char5e/class-name %)) (::char5e/classes char)))
+   (or (nil? has-portrait?)
+       (= has-portrait? (boolean (::char5e/image-url char))))
+   (or (nil? has-faction-pic?)
+       (= has-faction-pic? (boolean (::char5e/faction-image-url char))))))
+
+(defn filter-characters
+  "Filter `characters` by all active filter criteria."
+  [characters name-filter level-filters class-filters has-portrait? has-faction-pic?]
+  (filter #(char-matches? % name-filter level-filters class-filters has-portrait? has-faction-pic?)
+          characters))

--- a/src/cljc/orcpub/dnd/e5/folder.cljc
+++ b/src/cljc/orcpub/dnd/e5/folder.cljc
@@ -1,0 +1,7 @@
+(ns orcpub.dnd.e5.folder
+  (:require [clojure.spec.alpha :as spec]))
+
+(spec/def ::name string?)
+(spec/def ::character-id int?)
+(spec/def ::character-ids (spec/coll-of ::character-id))
+(spec/def ::folder (spec/keys :req [::name]))

--- a/src/cljc/orcpub/dnd/e5/folder.cljc
+++ b/src/cljc/orcpub/dnd/e5/folder.cljc
@@ -1,6 +1,7 @@
 (ns orcpub.dnd.e5.folder
   (:require [clojure.spec.alpha :as spec]))
 
+(spec/def ::owner string?)
 (spec/def ::name string?)
 (spec/def ::character-id int?)
 (spec/def ::character-ids (spec/coll-of ::character-id))

--- a/src/cljc/orcpub/route_map.cljc
+++ b/src/cljc/orcpub/route_map.cljc
@@ -15,6 +15,11 @@
 (def dnd-e5-char-party-characters-route :char-party-characters-5e)
 (def dnd-e5-char-party-character-route :char-party-character-5e)
 (def dnd-e5-char-parties-page-route :char-parties-5e-page)
+(def dnd-e5-char-folders-route :char-folders-5e)
+(def dnd-e5-char-folder-route :char-folder-5e)
+(def dnd-e5-char-folder-name-route :char-folder-name-5e)
+(def dnd-e5-char-folder-characters-route :char-folder-characters-5e)
+(def dnd-e5-char-folder-character-route :char-folder-character-5e)
 (def dnd-e5-orcacle-page-route :orcacle-page)
 
 (def dnd-e5-char-page-routes #{default-route
@@ -150,6 +155,11 @@
                                                 "/name" dnd-e5-char-party-name-route
                                                 "/characters" {"" dnd-e5-char-party-characters-route
                                                                ["/" :character-id] dnd-e5-char-party-character-route}}}
+                          "folders" {"" dnd-e5-char-folders-route
+                                     ["/" :id] {"" dnd-e5-char-folder-route
+                                                "/name" dnd-e5-char-folder-name-route
+                                                "/characters" {"" dnd-e5-char-folder-characters-route
+                                                               ["/" :character-id] dnd-e5-char-folder-character-route}}}
                           "character-summaries" dnd-e5-char-summary-list-route}}
                   "pages/" {"my-account" my-account-page-route
                             "register-page" register-page-route

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -888,10 +888,15 @@
                                :id folder-id
                                :character-id character-id)}}))
 
+;; When expanding a folder, collapse its characters so they start closed
 (reg-event-db
  ::folder5e/toggle-expanded
- (fn [db [_ folder-id]]
-   (update-in db [::folder5e/expanded folder-id] not)))
+ (fn [db [_ folder-id char-ids]]
+   (let [opening? (not (get-in db [::folder5e/expanded folder-id]))]
+     (cond-> (update-in db [::folder5e/expanded folder-id] not)
+       (and opening? (seq char-ids))
+       (update :expanded-characters
+               (fn [ec] (apply dissoc (or ec {}) char-ids)))))))
 
 (reg-event-db
  ::folder5e/toggle-renaming

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -18,6 +18,7 @@
             [orcpub.dnd.e5.classes :as class5e]
             [orcpub.dnd.e5.units :as units5e]
             [orcpub.dnd.e5.party :as party5e]
+            [orcpub.dnd.e5.folder :as folder5e]
             [orcpub.dnd.e5.character.random :as char-rand5e]
             [orcpub.dnd.e5.spells :as spells]
             [orcpub.dnd.e5.monsters :as monsters]
@@ -798,6 +799,104 @@
                 party))
             parties)))
     :dispatch [::party5e/add-character-remote id character-id show-confirmation?]}))
+
+;; ---- Folder Events -------------------------------------------------------
+
+(reg-event-db
+ ::folder5e/set-folders
+ (fn [db [_ folders]]
+   (assoc db ::folder5e/folders folders)))
+
+(reg-event-fx
+ ::folder5e/create-folder
+ (fn [{:keys [db]} [_]]
+   {:http {:method :post
+           :headers (authorization-headers db)
+           :transit-params {::folder5e/name "New Folder"}
+           :url (url-for-route routes/dnd-e5-char-folders-route)
+           :on-success [::folder5e/create-folder-success]}}))
+
+(reg-event-fx
+ ::folder5e/create-folder-success
+ (fn [{:keys [db]} [_ response]]
+   (let [folder (:body response)]
+     {:db (update db ::folder5e/folders conj folder)
+      :dispatch [::folder5e/toggle-renaming (:db/id folder)]})))
+
+(reg-event-fx
+ ::folder5e/rename-folder
+ (fn [{:keys [db]} [_ id new-name]]
+   {:db (update db ::folder5e/folders
+                (fn [folders]
+                  (map (fn [f]
+                         (if (= id (:db/id f))
+                           (assoc f ::folder5e/name new-name)
+                           f))
+                       folders)))
+    :http {:method :put
+           :headers (authorization-headers db)
+           :transit-params new-name
+           :url (url-for-route routes/dnd-e5-char-folder-name-route :id id)}}))
+
+(reg-event-fx
+ ::folder5e/delete-folder
+ (fn [{:keys [db]} [_ id]]
+   {:db (update db ::folder5e/folders
+                (fn [folders]
+                  (remove #(= id (:db/id %)) folders)))
+    :http {:method :delete
+           :headers (authorization-headers db)
+           :url (url-for-route routes/dnd-e5-char-folder-route :id id)}}))
+
+(reg-event-fx
+ ::folder5e/add-character
+ (fn [{:keys [db]} [_ folder-id character-id]]
+   {:db (update db ::folder5e/folders
+                (fn [folders]
+                  (map (fn [f]
+                         (if (= folder-id (:db/id f))
+                           (update f ::folder5e/character-ids
+                                   conj
+                                   (get-in db [::char5e/summary-map character-id]))
+                           ;; remove from any other folder (at-most-one constraint)
+                           (update f ::folder5e/character-ids
+                                   (fn [chars]
+                                     (remove #(= character-id (:db/id %)) chars)))))
+                       folders)))
+    :http {:method :post
+           :headers (authorization-headers db)
+           :transit-params character-id
+           :url (url-for-route routes/dnd-e5-char-folder-characters-route :id folder-id)}}))
+
+(reg-event-fx
+ ::folder5e/remove-character
+ (fn [{:keys [db]} [_ folder-id character-id]]
+   {:db (update db ::folder5e/folders
+                (fn [folders]
+                  (map (fn [f]
+                         (if (= folder-id (:db/id f))
+                           (update f ::folder5e/character-ids
+                                   (fn [chars]
+                                     (remove #(= character-id (:db/id %)) chars)))
+                           f))
+                       folders)))
+    :http {:method :delete
+           :headers (authorization-headers db)
+           :url (url-for-route routes/dnd-e5-char-folder-character-route
+                               :id folder-id
+                               :character-id character-id)}}))
+
+(reg-event-db
+ ::folder5e/toggle-expanded
+ (fn [db [_ folder-id]]
+   (update-in db [::folder5e/expanded folder-id] not)))
+
+(reg-event-db
+ ::folder5e/toggle-renaming
+ (fn [db [_ folder-id]]
+   (update-in db [::folder5e/renaming folder-id] not)))
+
+;; ---- End Folder Events ----------------------------------------------------
 
 (reg-event-fx
  :follow-user-success

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -362,6 +362,7 @@
         subrace (char5e/subrace built-char)
         character-name (char5e/character-name built-char)
         image-url (char5e/image-url built-char)
+        faction-image-url (char5e/faction-image-url built-char)
         age (char5e/age built-char)
         sex (char5e/sex built-char)
         height (char5e/height built-char)
@@ -369,11 +370,12 @@
         hair (char5e/hair built-char)
         eyes (char5e/eyes built-char)
         skin (char5e/skin built-char)
-        ;alignment (char5e/get-prop built-char ::alignment)  ;This is not available? 
-        ;background (char5e/get-prop built-char ::background)  ;This is not available? 
+        ;alignment (char5e/get-prop built-char ::alignment)  ;This is not available?
+        ;background (char5e/get-prop built-char ::background)  ;This is not available?
         ]
     (cond-> {::char5e/character-name (or character-name "")}
       image-url (assoc ::char5e/image-url image-url)
+      faction-image-url (assoc ::char5e/faction-image-url faction-image-url)
       race (assoc ::char5e/race-name race)
       subrace (assoc ::char5e/subrace-name subrace)
       age (assoc ::char5e/age age)
@@ -897,6 +899,51 @@
    (update-in db [::folder5e/renaming folder-id] not)))
 
 ;; ---- End Folder Events ----------------------------------------------------
+
+;; ---- Character Filter Events -----------------------------------------------
+
+(reg-event-db
+ ::char5e/set-char-name-filter
+ (fn [db [_ v]]
+   (assoc db ::char5e/char-name-filter v)))
+
+(reg-event-db
+ ::char5e/toggle-char-level-filter
+ (fn [db [_ level]]
+   (let [filters (or (get db ::char5e/char-level-filters) #{})]
+     (assoc db ::char5e/char-level-filters
+            ((if (filters level) disj conj) filters level)))))
+
+(reg-event-db
+ ::char5e/toggle-char-class-filter
+ (fn [db [_ cls]]
+   (let [filters (or (get db ::char5e/char-class-filters) #{})]
+     (assoc db ::char5e/char-class-filters
+            ((if (filters cls) disj conj) filters cls)))))
+
+(reg-event-db
+ ::char5e/toggle-char-has-portrait
+ (fn [db _]
+   (update db ::char5e/char-has-portrait?
+           #(case % nil true, true false, false nil))))
+
+(reg-event-db
+ ::char5e/toggle-char-has-faction-pic
+ (fn [db _]
+   (update db ::char5e/char-has-faction-pic?
+           #(case % nil true, true false, false nil))))
+
+(reg-event-db
+ ::char5e/clear-char-filters
+ (fn [db _]
+   (dissoc db
+           ::char5e/char-name-filter
+           ::char5e/char-level-filters
+           ::char5e/char-class-filters
+           ::char5e/char-has-portrait?
+           ::char5e/char-has-faction-pic?)))
+
+;; ---- End Character Filter Events -------------------------------------------
 
 (reg-event-fx
  :follow-user-success

--- a/src/cljs/orcpub/dnd/e5/subs.cljs
+++ b/src/cljs/orcpub/dnd/e5/subs.cljs
@@ -14,6 +14,7 @@
             [orcpub.dnd.e5.char-decision-tree :as char-dec5e]
             [orcpub.dnd.e5.character.equipment :as char-equip5e]
             [orcpub.dnd.e5.party :as party5e]
+            [orcpub.dnd.e5.folder :as folder5e]
             [orcpub.dnd.e5.monsters :as monsters5e]
             [orcpub.dnd.e5.spells :as spells5e]
             [orcpub.dnd.e5.armor :as armor5e]
@@ -389,6 +390,48 @@
    (subscribe [::party5e/parties login-optional?]))
  (fn [parties _]
    (common/map-by-id parties)))
+
+(reg-sub-raw
+  ::folder5e/folders
+  (fn [app-db _]
+    (go (dispatch [:set-loading true])
+        (let [response (<! (http/get (url-for-route routes/dnd-e5-char-folders-route)
+                                     {:headers (auth-headers @app-db)}))]
+          (dispatch [:set-loading false])
+          (case (:status response)
+            200 (dispatch [::folder5e/set-folders (:body response)])
+            401 (dispatch [:route-to-login])
+            500 (dispatch (events/show-generic-error)))))
+    (ra/make-reaction
+     (fn [] (get @app-db ::folder5e/folders [])))))
+
+(reg-sub
+ ::folder5e/folder-map
+ :<- [::folder5e/folders]
+ (fn [folders _]
+   (common/map-by-id folders)))
+
+(reg-sub
+ ::folder5e/expanded
+ (fn [db _]
+   (get db ::folder5e/expanded {})))
+
+(reg-sub
+ ::folder5e/renaming
+ (fn [db _]
+   (get db ::folder5e/renaming {})))
+
+(reg-sub
+ ::folder5e/character-folder-map
+ :<- [::folder5e/folders]
+ (fn [folders _]
+   (reduce (fn [m folder]
+             (reduce (fn [m char]
+                       (assoc m (:db/id char) (:db/id folder)))
+                     m
+                     (::folder5e/character-ids folder)))
+           {}
+           folders)))
 
 (reg-sub
  ::char5e/summary-map

--- a/src/cljs/orcpub/dnd/e5/subs.cljs
+++ b/src/cljs/orcpub/dnd/e5/subs.cljs
@@ -12,6 +12,7 @@
             [orcpub.dnd.e5.events :refer [url-for-route] :as events]
             [orcpub.dnd.e5.character :as char5e]
             [orcpub.dnd.e5.char-decision-tree :as char-dec5e]
+            [orcpub.dnd.e5.char-filter :as char-filter]
             [orcpub.dnd.e5.character.equipment :as char-equip5e]
             [orcpub.dnd.e5.party :as party5e]
             [orcpub.dnd.e5.folder :as folder5e]
@@ -1315,3 +1316,67 @@
  ::char5e/has-question-history?
  (fn [db _]
    (seq (get-in db [::char5e/question-history :newb-char-data]))))
+
+;; ---- Character List Filter Subscriptions -----------------------------------
+
+(reg-sub
+ ::char5e/char-name-filter
+ (fn [db _]
+   (get db ::char5e/char-name-filter "")))
+
+(reg-sub
+ ::char5e/char-level-filters
+ (fn [db _]
+   (get db ::char5e/char-level-filters #{})))
+
+(reg-sub
+ ::char5e/char-class-filters
+ (fn [db _]
+   (get db ::char5e/char-class-filters #{})))
+
+(reg-sub
+ ::char5e/char-has-portrait?
+ (fn [db _]
+   (get db ::char5e/char-has-portrait?)))
+
+(reg-sub
+ ::char5e/char-has-faction-pic?
+ (fn [db _]
+   (get db ::char5e/char-has-faction-pic?)))
+
+(reg-sub
+ ::char5e/char-classes-available
+ :<- [::char5e/characters]
+ (fn [characters _]
+   (->> characters
+        (mapcat ::char5e/classes)
+        (map ::char5e/class-name)
+        (remove nil?)
+        distinct
+        sort
+        vec)))
+
+(reg-sub
+ ::char5e/char-levels-available
+ :<- [::char5e/characters]
+ (fn [characters _]
+   (->> characters
+        (mapcat ::char5e/classes)
+        (map ::char5e/level)
+        (remove nil?)
+        distinct
+        sort
+        vec)))
+
+(reg-sub
+ ::char5e/filtered-characters
+ :<- [::char5e/characters]
+ :<- [::char5e/char-name-filter]
+ :<- [::char5e/char-level-filters]
+ :<- [::char5e/char-class-filters]
+ :<- [::char5e/char-has-portrait?]
+ :<- [::char5e/char-has-faction-pic?]
+ (fn [[characters name-filter level-filters class-filters has-portrait? has-faction-pic?] _]
+   (char-filter/filter-characters characters name-filter level-filters class-filters has-portrait? has-faction-pic?)))
+
+;; ---- End Character List Filter Subscriptions --------------------------------

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7794,7 +7794,8 @@
         [expanded-character-list-item id owner username char-page-route])]]))
 
 (defn folder-item [f expanded-characters selected-ids username filtered-char-ids]
-  (let [edit-name (r/atom (::folder/name f))]
+  (let [edit-name      (r/atom (::folder/name f))
+        confirm-delete? (r/atom false)]
     (fn [f expanded-characters selected-ids username filtered-char-ids]
       (let [folder-id (:db/id f)
             folder-name (::folder/name f)
@@ -7850,10 +7851,26 @@
           [:span.link-button.f-s-12
            {:on-click (fn [e]
                         (.stopPropagation e)
-                        (dispatch [::folder/delete-folder folder-id]))}
+                        (reset! confirm-delete? true))}
            "delete"]
-          [:i.fa.m-l-10.orange
-           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")}]])]
+          [:i.fa.m-l-10.orange.pointer
+           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")
+            :on-click   (make-event-handler ::folder/toggle-expanded folder-id)}]])]
+      (when @confirm-delete?
+        [:div.p-20.flex.justify-cont-end
+         [:div
+          [:div.m-b-10 "Are you sure you want to delete this folder? Characters will not be deleted."]
+          [:div.flex
+           [:button.form-button
+            {:on-click (fn [e]
+                         (.stopPropagation e)
+                         (reset! confirm-delete? false))}
+            "cancel"]
+           [:span.link-button.m-l-10
+            {:on-click (fn [e]
+                         (.stopPropagation e)
+                         (dispatch [::folder/delete-folder folder-id]))}
+            "delete"]]]])
       (if folder-expanded?
         [:div.item-list
          (doall

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7793,9 +7793,9 @@
       (if expanded?
         [expanded-character-list-item id owner username char-page-route])]]))
 
-(defn folder-item [f expanded-characters selected-ids username]
+(defn folder-item [f expanded-characters selected-ids username filtered-char-ids]
   (let [edit-name (r/atom (::folder/name f))]
-    (fn [f expanded-characters selected-ids username]
+    (fn [f expanded-characters selected-ids username filtered-char-ids]
       (let [folder-id (:db/id f)
             folder-name (::folder/name f)
             expanded? @(subscribe [::folder/expanded])
@@ -7803,6 +7803,9 @@
             renaming? @(subscribe [::folder/renaming])
             folder-renaming? (get renaming? folder-id)
             chars (::folder/character-ids f)
+            visible-chars (if (seq filtered-char-ids)
+                            (filter #(filtered-char-ids (:db/id %)) chars)
+                            chars)
             save-fn (fn []
                       (dispatch [::folder/rename-folder folder-id @edit-name])
                       (dispatch [::folder/toggle-renaming folder-id]))]
@@ -7835,7 +7838,7 @@
            folder-name])
         (when (not folder-renaming?)
           [:span.m-l-10.f-s-12.opacity-5
-           (str "(" (count chars) ")")])]
+           (str "(" (count visible-chars) ")")])]
        (when (not folder-renaming?)
          [:div.flex.align-items-c.m-r-10
           [:span.link-button.m-r-10.f-s-12
@@ -7864,7 +7867,7 @@
               owner
               username
               summary])
-           (sort-by ::char/character-name chars)))])]]))))
+           (sort-by ::char/character-name visible-chars)))])]]))))
 
 (defn orcacle-page []
   [content-page
@@ -8016,7 +8019,8 @@
      [:div.p-5
       [character-filter-bar]
       [:div
-       (let [grouped-characters (group-by ::se/owner characters)
+       (let [filtered-char-ids (into #{} (map :db/id) characters)
+             grouped-characters (group-by ::se/owner characters)
              user-characters (find grouped-characters username)
              other-characters (sort-by key (dissoc grouped-characters username))
              user-chars-list (second user-characters)
@@ -8029,7 +8033,7 @@
               (map
                (fn [f]
                  ^{:key (:db/id f)}
-                 [folder-item f expanded-characters selected-ids username])
+                 [folder-item f expanded-characters selected-ids username filtered-char-ids])
                user-folders))])
           (when (and username (seq unfiled-user-chars))
             [:div.m-b-40

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7804,21 +7804,21 @@
             renaming? @(subscribe [::folder/renaming])
             folder-renaming? (get renaming? folder-id)
             chars (::folder/character-ids f)
-            visible-chars (if (seq filtered-char-ids)
-                            (filter #(filtered-char-ids (:db/id %)) chars)
-                            chars)
+            visible-chars (filter #(filtered-char-ids (:db/id %)) chars)
             save-fn (fn []
                       (dispatch [::folder/rename-folder folder-id @edit-name])
                       (dispatch [::folder/toggle-renaming folder-id]))]
     [:div.main-text-color.item-list-item.m-b-5
      ^{:key folder-id}
      [:div
-      [:div.flex.justify-cont-s-b.align-items-c
+      ;; Entire row is clickable to expand/collapse folder
+      [:div.flex.justify-cont-s-b.align-items-c.pointer
+       {:on-click (when (not folder-renaming?)
+                    #(dispatch [::folder/toggle-expanded folder-id (mapv :db/id chars)]))}
        [:div.flex.align-items-c.m-l-10
         (when (not folder-renaming?)
-          [:i.fa.m-r-10.orange.pointer
-           {:class-name (if folder-expanded? "fa-folder-open" "fa-folder")
-            :on-click (make-event-handler ::folder/toggle-expanded folder-id)}])
+          [:i.fa.m-r-10.orange
+           {:class-name (if folder-expanded? "fa-folder-open" "fa-folder")}])
         (if folder-renaming?
           [:div.flex.align-items-c
            [:input.input
@@ -7834,8 +7834,7 @@
                          (.stopPropagation e)
                          (save-fn))}
             "save"]]
-          [:span.f-s-18.f-w-b.pointer
-           {:on-click (make-event-handler ::folder/toggle-expanded folder-id)}
+          [:span.f-s-18.f-w-b
            folder-name])
         (when (not folder-renaming?)
           [:span.m-l-10.f-s-12.opacity-5
@@ -7853,9 +7852,8 @@
                         (.stopPropagation e)
                         (reset! confirm-delete? true))}
            "delete"]
-          [:i.fa.m-l-10.orange.pointer
-           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")
-            :on-click   (make-event-handler ::folder/toggle-expanded folder-id)}]])]
+          [:i.fa.m-l-10.orange
+           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")}]])]
       (when @confirm-delete?
         [:div.p-20.flex.justify-cont-end
          [:div
@@ -7908,7 +7906,7 @@
                                  (seq class-filters)
                                  has-portrait?
                                  has-faction-pic?)]
-        [:div.main-text-color.m-b-10
+        [:div.main-text-color.m-b-10.char-filter-bar
          (when @classes-open?
            [:div.posn-fixed
             {:style    {:top 0 :left 0 :right 0 :bottom 0 :z-index 100}
@@ -7938,27 +7936,17 @@
             (str "Classes" (when (seq class-filters) (str " (" (count class-filters) ")")))
             [:i.fa.m-l-5 {:class-name (if @classes-open? "fa-caret-up" "fa-caret-down")}]]
            (when @classes-open?
-             [:div.posn-abs.main-text-color
-              {:style {:z-index      200
-                       :background   "rgba(0,0,0,0.92)"
-                       :padding      "10px"
-                       :min-width    "160px"
-                       :top          "105%"
-                       :border       "1px solid rgba(255,255,255,0.15)"
-                       :border-radius "4px"
-                       :max-height   "300px"
-                       :overflow-y   "auto"
-                       :font-weight  "normal"
-                       :font-size    "small"}}
+             [:div.filter-dropdown.main-text-color
+              {:style {:min-width "160px"}}
               (if (seq avail-classes)
                 (doall
                  (map (fn [cls]
                         ^{:key cls}
-                        [:div {:style {:margin-bottom "3px"}}
+                        [:div.filter-dropdown-item
                          [comps/labeled-checkbox cls (contains? class-filters cls) false
                           (fn [] (dispatch [::char/toggle-char-class-filter cls]))]])
                       avail-classes))
-                [:span.opacity-5.f-s-12 "No classes yet"])])]
+                [:span.opacity-5.f-s-12.p-5 "No classes yet"])])]
 
           ;; Levels multi-select dropdown
           [:div.posn-rel.m-r-5.m-b-5
@@ -7968,27 +7956,17 @@
             (str "Levels" (when (seq level-filters) (str " (" (count level-filters) ")")))
             [:i.fa.m-l-5 {:class-name (if @levels-open? "fa-caret-up" "fa-caret-down")}]]
            (when @levels-open?
-             [:div.posn-abs.main-text-color.center
-              {:style {:z-index       200
-                       :background    "rgba(0,0,0,0.92)"
-                       :padding       "10px"
-                       :min-width     "110px"
-                       :top           "105%"
-                       :border        "1px solid rgba(255,255,255,0.15)"
-                       :border-radius "4px"
-                       :max-height    "300px"
-                       :overflow-y    "auto"
-                       :font-weight   "normal"
-                       :font-size     "small"}}
+             [:div.filter-dropdown.main-text-color
+              {:style {:min-width "120px"}}
               (if (seq avail-levels)
                 (doall
                  (map (fn [lvl]
                         ^{:key lvl}
-                        [:div {:style {:margin-bottom "3px"}}
+                        [:div.filter-dropdown-item
                          [comps/labeled-checkbox (str "Level " lvl) (contains? level-filters lvl) false
                           (fn [] (dispatch [::char/toggle-char-level-filter lvl]))]])
                       avail-levels))
-                [:span.opacity-5.f-s-12 "No levels yet"])])]
+                [:span.opacity-5.f-s-12.p-5 "No levels yet"])])]
 
           ;; Portrait toggle (nil=all, true=with portrait, false=without portrait)
           [:button.form-button.m-r-5.m-b-5

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -20,6 +20,7 @@
             [orcpub.dnd.e5.feats :as feats]
             [orcpub.dnd.e5.units :as units]
             [orcpub.dnd.e5.party :as party]
+            [orcpub.dnd.e5.folder :as folder]
             [orcpub.dnd.e5.character.random :as char-random]
             [orcpub.dnd.e5.character.equipment :as char-equip]
             [orcpub.registration :as registration]
@@ -7701,47 +7702,65 @@
   (builder-page "Feat" ::feats/reset-feat ::feats/save-feat feat-builder))
 
 (defn expanded-character-list-item [id owner username char-page-route]
-  [:div
-   {:style character-display-style}
-   [:div.flex.justify-cont-end.uppercase.align-items-c
-    [share-link id]
-    (if (= username owner)
-      [:button.form-button
-       {:on-click (make-event-handler :edit-character @(subscribe [::char/character id]))}
-       "edit"])
-    (if (= username owner)
-      [:button.form-button.m-l-5
-       {:on-click (make-event-handler ::char/save-character id)}
-       "save"])
-    [:button.form-button.m-l-5
-     {:on-click (make-event-handler :route char-page-route)}
-     "view"]
-    [:button.form-button.m-l-5
-     {:on-click (export-pdf
-                 @(subscribe [::char/built-character id])
-                 id
-                 {:print-character-sheet? true
-                  :print-spell-cards? true
-                  :print-prepared-spells? false
-                  :print-character-sheet-style? 1
-                  :print-spell-card-dc-mod? true})}
-     "print"]
-    (if (= username owner)
-      [:button.form-button.m-l-5
-       {:on-click (make-event-handler ::char/show-delete-confirmation id)}
-       "delete"])]
-   (if @(subscribe [::char/delete-confirmation-shown? id])
-     [:div.p-20.flex.justify-cont-end
-      [:div
-       [:div.m-b-10 "Are you sure you want to delete this character?"]
-       [:div.flex
+  (let [folders @(subscribe [::folder/folders])
+        char-folder-map @(subscribe [::folder/character-folder-map])
+        current-folder-id (get char-folder-map id)]
+    [:div
+     {:style character-display-style}
+     [:div.flex.justify-cont-end.uppercase.align-items-c
+      [share-link id]
+      (if (= username owner)
         [:button.form-button
-         {:on-click (make-event-handler ::char/hide-delete-confirmation id)}
-         "cancel"]
-        [:span.link-button
-         {:on-click (make-event-handler :delete-character id)}
-         "delete"]]]])
-   [character-display id false (if (= :mobile @(subscribe [:device-type])) 1 2)]])
+         {:on-click (make-event-handler :edit-character @(subscribe [::char/character id]))}
+         "edit"])
+      (if (= username owner)
+        [:button.form-button.m-l-5
+         {:on-click (make-event-handler ::char/save-character id)}
+         "save"])
+      [:button.form-button.m-l-5
+       {:on-click (make-event-handler :route char-page-route)}
+       "view"]
+      [:button.form-button.m-l-5
+       {:on-click (export-pdf
+                   @(subscribe [::char/built-character id])
+                   id
+                   {:print-character-sheet? true
+                    :print-spell-cards? true
+                    :print-prepared-spells? false
+                    :print-character-sheet-style? 1
+                    :print-spell-card-dc-mod? true})}
+       "print"]
+      (if (and (= username owner) (seq folders))
+        [:select.form-button.m-l-5.builder-dropdown
+         {:value (or current-folder-id "")
+          :on-change (fn [e]
+                       (let [val (.-value (.-target e))]
+                         (if (= val "")
+                           (when current-folder-id
+                             (dispatch [::folder/remove-character current-folder-id id]))
+                           (dispatch [::folder/add-character (js/parseInt val) id]))))}
+         [:option.builder-dropdown-item {:value ""} "No folder"]
+         (doall
+          (map (fn [f]
+                 ^{:key (:db/id f)}
+                 [:option.builder-dropdown-item {:value (:db/id f)} (::folder/name f)])
+               (sort-by ::folder/name folders)))])
+      (if (= username owner)
+        [:button.form-button.m-l-5
+         {:on-click (make-event-handler ::char/show-delete-confirmation id)}
+         "delete"])]
+     (if @(subscribe [::char/delete-confirmation-shown? id])
+       [:div.p-20.flex.justify-cont-end
+        [:div
+         [:div.m-b-10 "Are you sure you want to delete this character?"]
+         [:div.flex
+          [:button.form-button
+           {:on-click (make-event-handler ::char/hide-delete-confirmation id)}
+           "cancel"]
+          [:span.link-button
+           {:on-click (make-event-handler :delete-character id)}
+           "delete"]]]])
+     [character-display id false (if (= :mobile @(subscribe [:device-type])) 1 2)]]))
 
 (defn character-list-item [expanded-characters
                            selected-ids
@@ -7774,6 +7793,79 @@
       (if expanded?
         [expanded-character-list-item id owner username char-page-route])]]))
 
+(defn folder-item [f expanded-characters selected-ids username]
+  (let [edit-name (r/atom (::folder/name f))]
+    (fn [f expanded-characters selected-ids username]
+      (let [folder-id (:db/id f)
+            folder-name (::folder/name f)
+            expanded? @(subscribe [::folder/expanded])
+            folder-expanded? (get expanded? folder-id)
+            renaming? @(subscribe [::folder/renaming])
+            folder-renaming? (get renaming? folder-id)
+            chars (::folder/character-ids f)
+            save-fn (fn []
+                      (dispatch [::folder/rename-folder folder-id @edit-name])
+                      (dispatch [::folder/toggle-renaming folder-id]))]
+    [:div.main-text-color.item-list-item.m-b-5
+     ^{:key folder-id}
+     [:div
+      [:div.flex.justify-cont-s-b.align-items-c
+       [:div.flex.align-items-c.m-l-10
+        (when (not folder-renaming?)
+          [:i.fa.m-r-10.orange.pointer
+           {:class-name (if folder-expanded? "fa-folder-open" "fa-folder")
+            :on-click (make-event-handler ::folder/toggle-expanded folder-id)}])
+        (if folder-renaming?
+          [:div.flex.align-items-c
+           [:input.input
+            {:auto-focus true
+             :value @edit-name
+             :style {:width "160px"}
+             :on-change #(reset! edit-name (.-value (.-target %)))
+             :on-key-down (fn [e]
+                            (when (= "Enter" (.-key e))
+                              (save-fn)))}]
+           [:button.form-button.m-l-5
+            {:on-click (fn [e]
+                         (.stopPropagation e)
+                         (save-fn))}
+            "save"]]
+          [:span.f-s-18.f-w-b.pointer
+           {:on-click (make-event-handler ::folder/toggle-expanded folder-id)}
+           folder-name])
+        (when (not folder-renaming?)
+          [:span.m-l-10.f-s-12.opacity-5
+           (str "(" (count chars) ")")])]
+       (when (not folder-renaming?)
+         [:div.flex.align-items-c.m-r-10
+          [:span.link-button.m-r-10.f-s-12
+           {:on-click (fn [e]
+                        (.stopPropagation e)
+                        (reset! edit-name folder-name)
+                        (dispatch [::folder/toggle-renaming folder-id]))}
+           "rename"]
+          [:span.link-button.f-s-12
+           {:on-click (fn [e]
+                        (.stopPropagation e)
+                        (dispatch [::folder/delete-folder folder-id]))}
+           "delete"]
+          [:i.fa.m-l-10.orange
+           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")}]])]
+      (if folder-expanded?
+        [:div.item-list
+         (doall
+          (map
+           (fn [{:keys [:db/id ::se/owner] :as summary}]
+             ^{:key (:db/id summary)}
+             [character-list-item
+              expanded-characters
+              selected-ids
+              (:db/id summary)
+              owner
+              username
+              summary])
+           (sort-by ::char/character-name chars)))])]]))))
+
 (defn orcacle-page []
   [content-page
    "Orcacle"
@@ -7782,8 +7874,9 @@
 
 (defn character-list []
   (let [characters @(subscribe [::char/characters])
+        folders @(subscribe [::folder/folders])
+        char-folder-map @(subscribe [::folder/character-folder-map])
         expanded-characters @(subscribe [:expanded-characters])
-        device-type @(subscribe [:device-type])
         username @(subscribe [:username])
         selected-ids @(subscribe [::char/selected])
         has-selected? @(subscribe [::char/has-selected?])]
@@ -7795,36 +7888,65 @@
       {:title "Make Party"
        :icon "users"
        :class-name (if (not has-selected?) "opacity-5 cursor-disabled")
-       :on-click (if has-selected? (make-event-handler ::party/make-party selected-ids))}]
+       :on-click (if has-selected? (make-event-handler ::party/make-party selected-ids))}
+      {:title "New Folder"
+       :icon "folder"
+       :on-click #(dispatch [::folder/create-folder])}]
      [:div.p-5
       [:div
        (let [grouped-characters (group-by ::se/owner characters)
              user-characters (find grouped-characters username)
              other-characters (sort-by key (dissoc grouped-characters username))
-             sorted-groups (if user-characters
-                             (cons user-characters other-characters)
-                             other-characters)]
-         (doall
-          (map
-           (fn [[owner owner-characters]]
-             ^{:key owner}
-             [:div.m-b-40
-              [:div.m-b-10.main-text-color.f-w-b.f-s-16
-               [other-user-component owner "f-s-24 m-l-10 m-r-20 i" true]]
-              [:div.item-list
-               (doall
-                (map
-                 (fn [{:keys [:db/id ::se/owner] :as summary}]
-                   ^{:key id}
-                   [character-list-item
-                    expanded-characters
-                    selected-ids
-                    id
-                    owner
-                    username
-                    summary])
-                 (sort-by ::char/character-name owner-characters)))]])
-           sorted-groups)))]]]))
+             user-chars-list (second user-characters)
+             unfiled-user-chars (remove #(get char-folder-map (:db/id %)) user-chars-list)
+             user-folders (sort-by ::folder/name folders)]
+         [:div
+          (when (and username (seq user-folders))
+            [:div.m-b-20
+             (doall
+              (map
+               (fn [f]
+                 ^{:key (:db/id f)}
+                 [folder-item f expanded-characters selected-ids username])
+               user-folders))])
+          (when (and username (seq unfiled-user-chars))
+            [:div.m-b-40
+             (when (seq user-folders)
+               [:div.m-b-10.main-text-color.f-s-14.opacity-5 "Unfiled"])
+             [:div.item-list
+              (doall
+               (map
+                (fn [{:keys [:db/id ::se/owner] :as summary}]
+                  ^{:key (:db/id summary)}
+                  [character-list-item
+                   expanded-characters
+                   selected-ids
+                   (:db/id summary)
+                   owner
+                   username
+                   summary])
+                (sort-by ::char/character-name unfiled-user-chars)))]])
+          (doall
+           (map
+            (fn [[owner owner-characters]]
+              ^{:key owner}
+              [:div.m-b-40
+               [:div.m-b-10.main-text-color.f-w-b.f-s-16
+                [other-user-component owner "f-s-24 m-l-10 m-r-20 i" true]]
+               [:div.item-list
+                (doall
+                 (map
+                  (fn [{:keys [:db/id ::se/owner] :as summary}]
+                    ^{:key (:db/id summary)}
+                    [character-list-item
+                     expanded-characters
+                     selected-ids
+                     (:db/id summary)
+                     owner
+                     username
+                     summary])
+                  (sort-by ::char/character-name owner-characters)))]])
+            (sort-by key other-characters)))])]]]))
 
 (def party-name-editor-style
   {:width "200px"
@@ -8228,3 +8350,4 @@
          {:style close-icon-style
           :on-click (make-event-handler ::char/filter-items "")}]]]
       [item-list-items]]]))
+

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7872,8 +7872,129 @@
    []
    [orcacle]])
 
+(defn character-filter-bar []
+  (let [classes-open? (r/atom false)
+        levels-open? (r/atom false)]
+    (fn []
+      (let [name-filter      @(subscribe [::char/char-name-filter])
+            level-filters    @(subscribe [::char/char-level-filters])
+            class-filters    @(subscribe [::char/char-class-filters])
+            has-portrait?    @(subscribe [::char/char-has-portrait?])
+            has-faction-pic? @(subscribe [::char/char-has-faction-pic?])
+            avail-classes    @(subscribe [::char/char-classes-available])
+            avail-levels     @(subscribe [::char/char-levels-available])
+            any-filter?      (or (not (s/blank? name-filter))
+                                 (seq level-filters)
+                                 (seq class-filters)
+                                 has-portrait?
+                                 has-faction-pic?)]
+        [:div.main-text-color.m-b-10
+         (when @classes-open?
+           [:div.posn-fixed
+            {:style    {:top 0 :left 0 :right 0 :bottom 0 :z-index 100}
+             :on-click (fn [e] (.stopPropagation e) (reset! classes-open? false))}])
+         (when @levels-open?
+           [:div.posn-fixed
+            {:style    {:top 0 :left 0 :right 0 :bottom 0 :z-index 100}
+             :on-click (fn [e] (.stopPropagation e) (reset! levels-open? false))}])
+         [:div.flex.align-items-c.flex-wrap.p-5
+          ;; Name search
+          [:div.posn-rel.m-r-5.m-b-5
+           [:input.input
+            {:placeholder "Search by name..."
+             :style       {:width "200px"}
+             :value       name-filter
+             :on-change   #(dispatch [::char/set-char-name-filter (.. % -target -value)])}]
+           (when (not (s/blank? name-filter))
+             [:i.fa.fa-times.posn-abs.pointer.orange.f-s-14
+              {:style    {:right "8px" :top "8px"}
+               :on-click #(dispatch [::char/set-char-name-filter ""])}])]
+
+          ;; Classes multi-select dropdown
+          [:div.posn-rel.m-r-5.m-b-5
+           {:style {:z-index (if @classes-open? 200 1)}}
+           [:button.form-button
+            {:on-click (fn [e] (.stopPropagation e) (swap! classes-open? not))}
+            (str "Classes" (when (seq class-filters) (str " (" (count class-filters) ")")))
+            [:i.fa.m-l-5 {:class-name (if @classes-open? "fa-caret-up" "fa-caret-down")}]]
+           (when @classes-open?
+             [:div.posn-abs.main-text-color
+              {:style {:z-index      200
+                       :background   "rgba(0,0,0,0.92)"
+                       :padding      "10px"
+                       :min-width    "160px"
+                       :top          "105%"
+                       :border       "1px solid rgba(255,255,255,0.15)"
+                       :border-radius "4px"
+                       :max-height   "300px"
+                       :overflow-y   "auto"
+                       :font-weight  "normal"
+                       :font-size    "small"}}
+              (if (seq avail-classes)
+                (doall
+                 (map (fn [cls]
+                        ^{:key cls}
+                        [:div {:style {:margin-bottom "3px"}}
+                         [comps/labeled-checkbox cls (contains? class-filters cls) false
+                          (fn [] (dispatch [::char/toggle-char-class-filter cls]))]])
+                      avail-classes))
+                [:span.opacity-5.f-s-12 "No classes yet"])])]
+
+          ;; Levels multi-select dropdown
+          [:div.posn-rel.m-r-5.m-b-5
+           {:style {:z-index (if @levels-open? 200 1)}}
+           [:button.form-button
+            {:on-click (fn [e] (.stopPropagation e) (swap! levels-open? not))}
+            (str "Levels" (when (seq level-filters) (str " (" (count level-filters) ")")))
+            [:i.fa.m-l-5 {:class-name (if @levels-open? "fa-caret-up" "fa-caret-down")}]]
+           (when @levels-open?
+             [:div.posn-abs.main-text-color.center
+              {:style {:z-index       200
+                       :background    "rgba(0,0,0,0.92)"
+                       :padding       "10px"
+                       :min-width     "110px"
+                       :top           "105%"
+                       :border        "1px solid rgba(255,255,255,0.15)"
+                       :border-radius "4px"
+                       :max-height    "300px"
+                       :overflow-y    "auto"
+                       :font-weight   "normal"
+                       :font-size     "small"}}
+              (if (seq avail-levels)
+                (doall
+                 (map (fn [lvl]
+                        ^{:key lvl}
+                        [:div {:style {:margin-bottom "3px"}}
+                         [comps/labeled-checkbox (str "Level " lvl) (contains? level-filters lvl) false
+                          (fn [] (dispatch [::char/toggle-char-level-filter lvl]))]])
+                      avail-levels))
+                [:span.opacity-5.f-s-12 "No levels yet"])])]
+
+          ;; Portrait toggle (nil=all, true=with portrait, false=without portrait)
+          [:button.form-button.m-r-5.m-b-5
+           {:on-click #(dispatch [::char/toggle-char-has-portrait])}
+           [:i.fa.fa-user.m-r-5]
+           (cond (true? has-portrait?)  "Portrait: Has"
+                 (false? has-portrait?) "Portrait: None"
+                 :else                  "Portrait: All")]
+
+          ;; Faction Pic toggle (nil=all, true=with faction pic, false=without faction pic)
+          [:button.form-button.m-r-5.m-b-5
+           {:on-click #(dispatch [::char/toggle-char-has-faction-pic])}
+           [:i.fa.fa-flag.m-r-5]
+           (cond (true? has-faction-pic?)  "Faction Pic: Has"
+                 (false? has-faction-pic?) "Faction Pic: None"
+                 :else                     "Faction Pic: All")]
+
+          ;; Clear button — only shown when any filter is active
+          (when any-filter?
+            [:button.form-button.m-b-5
+             {:on-click #(dispatch [::char/clear-char-filters])}
+             [:i.fa.fa-times.m-r-5]
+             "Clear"])]]))))
+
 (defn character-list []
-  (let [characters @(subscribe [::char/characters])
+  (let [characters @(subscribe [::char/filtered-characters])
         folders @(subscribe [::folder/folders])
         char-folder-map @(subscribe [::folder/character-folder-map])
         expanded-characters @(subscribe [:expanded-characters])
@@ -7893,6 +8014,7 @@
        :icon "folder"
        :on-click #(dispatch [::folder/create-folder])}]
      [:div.p-5
+      [character-filter-bar]
       [:div
        (let [grouped-characters (group-by ::se/owner characters)
              user-characters (find grouped-characters username)

--- a/test/clj/orcpub/routes/folder_test.clj
+++ b/test/clj/orcpub/routes/folder_test.clj
@@ -92,7 +92,8 @@
         (let [body (:body (folder/folders {:db       (d/db mocked-conn)
                                            :identity {:user "alice"}}))]
           (is (= 2 (count body)))
-          (is (every? #(= "alice" (::folder5e/owner %)) body))))
+          (is (= #{"Alice Folder 1" "Alice Folder 2"}
+                 (into #{} (map ::folder5e/name) body)))))
       (testing "bob sees only his own folder"
         (let [body (:body (folder/folders {:db       (d/db mocked-conn)
                                            :identity {:user "bob"}}))]

--- a/test/clj/orcpub/routes/folder_test.clj
+++ b/test/clj/orcpub/routes/folder_test.clj
@@ -1,0 +1,229 @@
+(ns orcpub.routes.folder-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datomic.api :as d]
+            [datomock.core :as dm]
+            [orcpub.routes :as routes]
+            [orcpub.routes.folder :as folder]
+            [orcpub.db.schema :as schema]
+            [orcpub.entity.strict :as se]
+            [orcpub.dnd.e5.folder :as folder5e]
+            [orcpub.dnd.e5.character :as char5e])
+  (:import [java.util UUID]))
+
+;; ---------------------------------------------------------------------------
+;; Test helpers
+
+(defmacro with-conn [conn-binding & body]
+  `(let [uri# (str "datomic:mem:folder-test-" (UUID/randomUUID))
+         ~conn-binding (do
+                         (d/create-database uri#)
+                         (d/connect uri#))]
+     (try ~@body
+          (finally (d/delete-database uri#)))))
+
+(defn setup-db! [conn]
+  @(d/transact conn schema/all-schemas)
+  @(d/transact conn [{:orcpub.user/username "alice"
+                      :orcpub.user/email    "alice@test.com"}
+                     {:orcpub.user/username "bob"
+                      :orcpub.user/email    "bob@test.com"}]))
+
+(defn test-character []
+  {::se/selections
+   [{::se/key :ability-scores
+     ::se/option
+     {::se/key :standard-scores
+      ::se/map-value
+      {::char5e/str 15
+       ::char5e/dex 14
+       ::char5e/con 13
+       ::char5e/int 12
+       ::char5e/wis 10
+       ::char5e/cha 8}}}
+    {::se/key :class
+     ::se/options
+     [{::se/key :fighter
+       ::se/selections
+       [{::se/key :levels
+         ::se/options [{::se/key :level-1}]}]}]}]
+   ::se/summary
+   {::char5e/character-name "Aragorn"
+    ::char5e/classes        [{::char5e/class-name "Fighter"
+                              ::char5e/level      1}]}})
+
+(defn save-char! [conn username]
+  (:body (routes/do-save-character (d/db conn) conn (test-character) {:user username})))
+
+(defn create-folder! [conn username folder-name]
+  (:body (folder/create-folder {:conn           conn
+                                :identity       {:user username}
+                                :transit-params {::folder5e/name folder-name}})))
+
+;; ---------------------------------------------------------------------------
+;; create-folder
+
+(deftest test-create-folder
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)
+          result      (folder/create-folder {:conn           mocked-conn
+                                             :identity       {:user "alice"}
+                                             :transit-params {::folder5e/name "Campaign 1"}})]
+      (testing "returns HTTP 200"
+        (is (= 200 (:status result))))
+      (testing "body has correct name"
+        (is (= "Campaign 1" (::folder5e/name (:body result)))))
+      (testing "body has correct owner"
+        (is (= "alice" (::folder5e/owner (:body result)))))
+      (testing "body has a db/id"
+        (is (int? (:db/id (:body result))))))))
+
+;; ---------------------------------------------------------------------------
+;; folders (list)
+
+(deftest test-list-folders
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)]
+      (create-folder! mocked-conn "alice" "Alice Folder 1")
+      (create-folder! mocked-conn "alice" "Alice Folder 2")
+      (create-folder! mocked-conn "bob"   "Bob Folder")
+      (testing "alice sees only her own folders"
+        (let [body (:body (folder/folders {:db       (d/db mocked-conn)
+                                           :identity {:user "alice"}}))]
+          (is (= 2 (count body)))
+          (is (every? #(= "alice" (::folder5e/owner %)) body))))
+      (testing "bob sees only his own folder"
+        (let [body (:body (folder/folders {:db       (d/db mocked-conn)
+                                           :identity {:user "bob"}}))]
+          (is (= 1 (count body)))
+          (is (= "Bob Folder" (::folder5e/name (first body)))))))))
+
+;; ---------------------------------------------------------------------------
+;; update-folder-name
+
+(deftest test-update-folder-name
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)
+          created     (create-folder! mocked-conn "alice" "Old Name")
+          folder-id   (:db/id created)
+          result      (folder/update-folder-name {:conn           mocked-conn
+                                                  :transit-params "New Name"
+                                                  :path-params    {:id folder-id}})]
+      (testing "returns HTTP 200"
+        (is (= 200 (:status result))))
+      (testing "folder name is updated"
+        (is (= "New Name" (::folder5e/name (:body result))))))))
+
+;; ---------------------------------------------------------------------------
+;; add-character
+
+(deftest test-add-character
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)
+          saved-char  (save-char! mocked-conn "alice")
+          char-id     (:db/id saved-char)
+          folder      (create-folder! mocked-conn "alice" "My Folder")
+          folder-id   (:db/id folder)
+          result      (folder/add-character {:db             (d/db mocked-conn)
+                                             :conn           mocked-conn
+                                             :transit-params char-id
+                                             :path-params    {:id folder-id}})]
+      (testing "returns HTTP 200"
+        (is (= 200 (:status result))))
+      (testing "folder now contains the character"
+        (let [char-ids (->> (:body result)
+                            ::folder5e/character-ids
+                            (map :db/id)
+                            set)]
+          (is (contains? char-ids char-id)))))))
+
+(deftest test-add-character-at-most-one-folder
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)
+          saved-char  (save-char! mocked-conn "alice")
+          char-id     (:db/id saved-char)
+          folder-a    (create-folder! mocked-conn "alice" "Folder A")
+          folder-b    (create-folder! mocked-conn "alice" "Folder B")]
+      ;; Add character to Folder A
+      (folder/add-character {:db             (d/db mocked-conn)
+                             :conn           mocked-conn
+                             :transit-params char-id
+                             :path-params    {:id (:db/id folder-a)}})
+      ;; Add same character to Folder B — should remove from A first
+      (folder/add-character {:db             (d/db mocked-conn)
+                             :conn           mocked-conn
+                             :transit-params char-id
+                             :path-params    {:id (:db/id folder-b)}})
+      (let [db         (d/db mocked-conn)
+            a-chars    (d/q '[:find [?c ...]
+                              :in $ ?f
+                              :where [?f :orcpub.dnd.e5.folder/character-ids ?c]]
+                            db (:db/id folder-a))
+            b-chars    (d/q '[:find [?c ...]
+                              :in $ ?f
+                              :where [?f :orcpub.dnd.e5.folder/character-ids ?c]]
+                            db (:db/id folder-b))]
+        (testing "character is no longer in Folder A"
+          (is (empty? a-chars)))
+        (testing "character is in Folder B"
+          (is (= [char-id] b-chars)))))))
+
+;; ---------------------------------------------------------------------------
+;; remove-character
+
+(deftest test-remove-character
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)
+          saved-char  (save-char! mocked-conn "alice")
+          char-id     (:db/id saved-char)
+          folder      (create-folder! mocked-conn "alice" "My Folder")
+          folder-id   (:db/id folder)]
+      ;; First add the character
+      (folder/add-character {:db             (d/db mocked-conn)
+                             :conn           mocked-conn
+                             :transit-params char-id
+                             :path-params    {:id folder-id}})
+      ;; Then remove it
+      (let [result (folder/remove-character {:conn        mocked-conn
+                                             :path-params {:id           folder-id
+                                                           :character-id (str char-id)}})]
+        (testing "returns HTTP 200"
+          (is (= 200 (:status result))))
+        (testing "folder no longer contains the character"
+          (let [char-ids (->> (:body result)
+                              ::folder5e/character-ids
+                              (map :db/id)
+                              set)]
+            (is (not (contains? char-ids char-id)))))))))
+
+;; ---------------------------------------------------------------------------
+;; delete-folder
+
+(deftest test-delete-folder
+  (with-conn conn
+    (setup-db! conn)
+    (let [mocked-conn (dm/fork-conn conn)
+          saved-char  (save-char! mocked-conn "alice")
+          char-id     (:db/id saved-char)
+          folder      (create-folder! mocked-conn "alice" "Doomed Folder")
+          folder-id   (:db/id folder)]
+      ;; Add a character to the folder before deleting
+      (folder/add-character {:db             (d/db mocked-conn)
+                             :conn           mocked-conn
+                             :transit-params char-id
+                             :path-params    {:id folder-id}})
+      (let [result (folder/delete-folder {:conn        mocked-conn
+                                          :path-params {:id folder-id}})]
+        (testing "returns HTTP 200"
+          (is (= 200 (:status result))))
+        (testing "folder entity is gone from db"
+          (let [folder-entity (d/pull (d/db mocked-conn) '[*] folder-id)]
+            (is (= {:db/id folder-id} folder-entity))))
+        (testing "character entity is NOT deleted"
+          (let [char-entity (d/pull (d/db mocked-conn) '[*] char-id)]
+            (is (some? (::se/owner char-entity)))))))))

--- a/test/cljc/orcpub/dnd/e5/char_filter_test.clj
+++ b/test/cljc/orcpub/dnd/e5/char_filter_test.clj
@@ -1,0 +1,177 @@
+(ns orcpub.dnd.e5.char-filter-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [orcpub.dnd.e5.char-filter :as char-filter]
+            [orcpub.dnd.e5.character :as char5e]))
+
+;; ---------------------------------------------------------------------------
+;; Test data
+
+(def aragorn
+  {::char5e/character-name    "Aragorn"
+   ::char5e/image-url         "http://example.com/aragorn.png"
+   ::char5e/faction-image-url nil
+   ::char5e/classes           [{::char5e/class-name "Fighter" ::char5e/level 5}
+                               {::char5e/class-name "Ranger"  ::char5e/level 3}]})
+
+(def legolas
+  {::char5e/character-name    "Legolas"
+   ::char5e/image-url         nil
+   ::char5e/faction-image-url "http://example.com/mirkwood.png"
+   ::char5e/classes           [{::char5e/class-name "Ranger" ::char5e/level 8}]})
+
+(def gimli
+  {::char5e/character-name    "Gimli"
+   ::char5e/image-url         nil
+   ::char5e/faction-image-url nil
+   ::char5e/classes           [{::char5e/class-name "Fighter" ::char5e/level 10}]})
+
+(def all-chars [aragorn legolas gimli])
+
+;; Shorthand: call filter-characters with all filters defaulted to "no filter"
+(defn filter-by [& {:keys [name levels classes portrait faction]
+                    :or   {name "" levels #{} classes #{} portrait nil faction nil}}]
+  (vec (char-filter/filter-characters all-chars name levels classes portrait faction)))
+
+;; ---------------------------------------------------------------------------
+;; Name filter
+
+(deftest name-filter-blank-returns-all
+  (is (= all-chars (filter-by :name ""))))
+
+(deftest name-filter-case-insensitive-substring
+  (testing "lowercase query matches mixed-case name"
+    (is (= [aragorn] (filter-by :name "ara"))))
+  (testing "uppercase query matches"
+    (is (= [gimli] (filter-by :name "GIM"))))
+  (testing "no match returns empty"
+    (is (= [] (filter-by :name "xyz"))))
+  (testing "partial match across multiple chars"
+    (is (= [legolas gimli] (filter-by :name "l")))))
+
+(deftest name-filter-nil-treated-as-blank
+  ;; character-name may be nil for a newly-created character with no name set
+  (let [unnamed {::char5e/character-name    nil
+                 ::char5e/image-url         nil
+                 ::char5e/faction-image-url nil
+                 ::char5e/classes           []}
+        result (char-filter/filter-characters [unnamed] "" #{} #{} nil nil)]
+    (is (= [unnamed] (vec result)))))
+
+;; ---------------------------------------------------------------------------
+;; Level filter
+
+(deftest level-filter-empty-returns-all
+  (is (= all-chars (filter-by :levels #{}))))
+
+(deftest level-filter-matches-any-class-level
+  (testing "level 3 matches Aragorn (Ranger 3)"
+    (is (= [aragorn] (filter-by :levels #{3}))))
+  (testing "level 5 matches Aragorn (Fighter 5)"
+    (is (= [aragorn] (filter-by :levels #{5}))))
+  (testing "level 8 matches Legolas"
+    (is (= [legolas] (filter-by :levels #{8}))))
+  (testing "level in multiple chars"
+    (is (= (set [aragorn gimli]) (set (filter-by :levels #{5 10})))))
+  (testing "non-existent level returns empty"
+    (is (= [] (filter-by :levels #{99})))))
+
+;; ---------------------------------------------------------------------------
+;; Class filter
+
+(deftest class-filter-empty-returns-all
+  (is (= all-chars (filter-by :classes #{}))))
+
+(deftest class-filter-matches-any-class
+  (testing "Ranger matches Aragorn and Legolas"
+    (is (= (set [aragorn legolas]) (set (filter-by :classes #{"Ranger"})))))
+  (testing "Fighter matches Aragorn and Gimli"
+    (is (= (set [aragorn gimli]) (set (filter-by :classes #{"Fighter"})))))
+  (testing "multi-class filter: Fighter OR Ranger → all three"
+    (is (= (set all-chars) (set (filter-by :classes #{"Fighter" "Ranger"})))))
+  (testing "non-existent class returns empty"
+    (is (= [] (filter-by :classes #{"Rogue"})))))
+
+;; ---------------------------------------------------------------------------
+;; Portrait (has-portrait?) filter
+
+(deftest portrait-filter-nil-returns-all
+  (is (= all-chars (filter-by :portrait nil))))
+
+(deftest portrait-filter-true-returns-only-chars-with-portrait
+  (is (= [aragorn] (filter-by :portrait true))))
+
+(deftest portrait-filter-false-returns-chars-without-portrait
+  (is (= (set [legolas gimli]) (set (filter-by :portrait false)))))
+
+;; ---------------------------------------------------------------------------
+;; Faction-pic (has-faction-pic?) filter
+
+(deftest faction-filter-nil-returns-all
+  (is (= all-chars (filter-by :faction nil))))
+
+(deftest faction-filter-true-returns-only-chars-with-faction-pic
+  (is (= [legolas] (filter-by :faction true))))
+
+(deftest faction-filter-false-returns-chars-without-faction-pic
+  (is (= (set [aragorn gimli]) (set (filter-by :faction false)))))
+
+;; ---------------------------------------------------------------------------
+;; Combined filters (AND logic)
+
+(deftest combined-name-and-class-filter
+  (testing "name contains 'gorn' AND class is Ranger → Aragorn only"
+    (is (= [aragorn] (filter-by :name "gorn" :classes #{"Ranger"})))))
+
+(deftest combined-class-and-portrait-filter
+  (testing "Fighter AND has portrait → Aragorn only"
+    (is (= [aragorn] (filter-by :classes #{"Fighter"} :portrait true))))
+  (testing "Fighter AND no portrait → Gimli only"
+    (is (= [gimli] (filter-by :classes #{"Fighter"} :portrait false)))))
+
+(deftest combined-level-and-faction-filter
+  (testing "any level 8 AND has faction pic → Legolas"
+    (is (= [legolas] (filter-by :levels #{8} :faction true)))))
+
+;; ---------------------------------------------------------------------------
+;; Toggle event logic (pure functions, no re-frame required)
+
+(def toggle-set-item
+  "Pure fn matching the toggle-char-level-filter / toggle-char-class-filter logic."
+  (fn [db k v]
+    (let [filters (or (get db k) #{})]
+      (assoc db k ((if (filters v) disj conj) filters v)))))
+
+(deftest toggle-set-item-adds-to-empty-set
+  (let [db {}
+        result (toggle-set-item db ::char5e/char-level-filters 3)]
+    (is (= #{3} (::char5e/char-level-filters result)))))
+
+(deftest toggle-set-item-removes-existing-value
+  (let [db {::char5e/char-level-filters #{3 5}}
+        result (toggle-set-item db ::char5e/char-level-filters 3)]
+    (is (= #{5} (::char5e/char-level-filters result)))))
+
+(deftest toggle-set-item-adds-to-existing-set
+  (let [db {::char5e/char-level-filters #{5}}
+        result (toggle-set-item db ::char5e/char-level-filters 3)]
+    (is (= #{3 5} (::char5e/char-level-filters result)))))
+
+(deftest toggle-set-item-handles-nil-key-in-db
+  ;; When key not yet present, update must not call nil as a function
+  (let [db {}
+        result (toggle-set-item db ::char5e/char-class-filters "Rogue")]
+    (is (= #{"Rogue"} (::char5e/char-class-filters result)))))
+
+;; ---------------------------------------------------------------------------
+;; Tri-state cycle logic (portrait / faction-pic toggle)
+
+(def cycle-tristate #(case % nil true, true false, false nil))
+
+(deftest tristate-cycle-nil-to-true
+  (is (= true (cycle-tristate nil))))
+
+(deftest tristate-cycle-true-to-false
+  (is (= false (cycle-tristate true))))
+
+(deftest tristate-cycle-false-to-nil
+  (is (nil? (cycle-tristate false))))

--- a/test/cljc/orcpub/dnd/e5/folder_test.clj
+++ b/test/cljc/orcpub/dnd/e5/folder_test.clj
@@ -1,0 +1,62 @@
+(ns orcpub.dnd.e5.folder-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.spec.alpha :as spec]
+            [orcpub.dnd.e5.folder :as folder5e]))
+
+;; ---------------------------------------------------------------------------
+;; ::folder5e/name spec
+
+(deftest folder-name-valid
+  (is (spec/valid? ::folder5e/name "Campaign 1")))
+
+(deftest folder-name-empty-string-is-valid
+  ;; spec only requires string? — emptiness is a UI concern, not a spec constraint
+  (is (spec/valid? ::folder5e/name "")))
+
+(deftest folder-name-requires-string
+  (is (not (spec/valid? ::folder5e/name 42)))
+  (is (not (spec/valid? ::folder5e/name nil)))
+  (is (not (spec/valid? ::folder5e/name :keyword))))
+
+;; ---------------------------------------------------------------------------
+;; ::folder5e/character-id spec
+
+(deftest character-id-valid-int
+  (is (spec/valid? ::folder5e/character-id 1))
+  (is (spec/valid? ::folder5e/character-id 987654321)))
+
+(deftest character-id-requires-int
+  (is (not (spec/valid? ::folder5e/character-id "1")))
+  (is (not (spec/valid? ::folder5e/character-id nil))))
+
+;; ---------------------------------------------------------------------------
+;; ::folder5e/character-ids spec
+
+(deftest character-ids-valid-empty-collection
+  (is (spec/valid? ::folder5e/character-ids [])))
+
+(deftest character-ids-valid-collection-of-ints
+  (is (spec/valid? ::folder5e/character-ids [1 2 3])))
+
+(deftest character-ids-invalid-contains-non-int
+  (is (not (spec/valid? ::folder5e/character-ids ["abc"])))
+  (is (not (spec/valid? ::folder5e/character-ids [1 "two"]))))
+
+;; ---------------------------------------------------------------------------
+;; ::folder5e/folder spec
+
+(deftest folder-valid-with-required-name
+  (is (spec/valid? ::folder5e/folder {::folder5e/name "My Folder"})))
+
+(deftest folder-invalid-when-name-missing
+  (is (not (spec/valid? ::folder5e/folder {}))))
+
+(deftest folder-invalid-when-name-wrong-type
+  (is (not (spec/valid? ::folder5e/folder {::folder5e/name 123}))))
+
+(deftest folder-explain-data-nil-when-valid
+  (is (nil? (spec/explain-data ::folder5e/folder {::folder5e/name "Adventure"}))))
+
+(deftest folder-explain-data-non-nil-when-invalid
+  (is (some? (spec/explain-data ::folder5e/folder {})))
+  (is (some? (spec/explain-data ::folder5e/folder {::folder5e/name nil}))))


### PR DESCRIPTION
## Description:
Fixes #52 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation if necessary
  - [x] There is no commented out code in this PR.
  - [x] My changes generate no new warnings (check the console)
  - [x] My changes include tests for lein test
  
  **Character Folders — COMPLETE:**
- [x] Folder spec (`src/cljc/orcpub/dnd/e5/folder.cljc`) — minimal `::name` spec
- [x] Datomic schema attributes (`src/clj/orcpub/db/schema.clj`)
- [x] Backend route handlers (`src/clj/orcpub/routes/folder.clj`):
  - `create-folder`, `folders` (list with characters), `update-folder-name`
  - `add-character` (with at-most-one-folder enforcement), `remove-character`, `delete-folder`
- [x] Routes registered in `pedestal.clj`
- [x] Re-frame events: `create-folder`, `load-folders`, `rename-folder`, `add-char-to-folder`, `remove-char-from-folder`, `delete-folder`
- [x] Re-frame subscriptions: `::folders`, `::folder-items`
- [x] Frontend UI: folder list, create/rename/delete, assign characters

**Character List Search & Filter — COMPLETE:**

- [x] `faction-image-url` added to `make-summary` (events.cljs)
- [x] 6 filter events: `set-char-name-filter`, `toggle-char-level-filter`, `toggle-char-class-filter`, `toggle-char-has-portrait`, `toggle-char-has-faction-pic`, `clear-char-filters`
- [x] 7 filter subscriptions: 5 state subs + `char-classes-available` + `char-levels-available` + `filtered-characters`
- [x] `character-filter-bar` component: name search, classes dropdown, levels dropdown, portrait tri-state, faction-pic tri-state, clear button
- [x] `character-list` updated to use `::char/filtered-characters`

**Tests — COMPLETE:**

- [x] `test/cljc/orcpub/dnd/e5/char_filter_test.clj` — 36 tests (all filter logic, toggle/tri-state event logic)
- [x] `test/clj/orcpub/routes/folder_test.clj` — all 6 route handlers (datomock), at-most-one-folder enforcement
- [x] `test/cljc/orcpub/dnd/e5/folder_test.clj` — folder spec validation